### PR TITLE
Verbose equivalence

### DIFF
--- a/CompareBiggerObjects.ps1
+++ b/CompareBiggerObjects.ps1
@@ -1,0 +1,27 @@
+Get-Module Assert | remove-module ;
+Import-module .\Assert.psd1
+
+$expected = [PSCustomObject]@{ 
+    Name = 'Jakub' 
+    Age = 28
+    KnowsPowerShell = $true
+    Languages = 'Czech', 'English' 
+    ProgrammingLanguage =
+        [PSCustomObject]@{
+            Name = 'PowerShell'
+            Type = 'Scripting'
+        }
+}
+
+$actual = [PSCustomObject]@{ 
+    Name = 'Jkb'
+    KnowsPowerShell = 0
+    Languages = 'Czech', 'English', 'German'
+    ProgrammingLanguage = 
+        [PSCustomObject]@{
+            Name = 'C#'
+            Type = 'ObjectOriented'
+        }    
+}
+
+Assert-Equivalent -a $actual -e $expected -Verbose

--- a/VerboseOutput.ps1
+++ b/VerboseOutput.ps1
@@ -1,0 +1,70 @@
+Get-Module Assert | remove-module ;
+Import-module .\Assert.psd1
+
+# messages:
+# (in the result use $(Format-Nicely $variable) for the $Expected and $Actual messages so we can see what was actually there and detect errors better))
+# expectation -> v "`$Expected is `$null, so we are expecting `$null."
+# v -Difference "`$Actual is not equivalent to `$null, because it has a value of type $(Format-Nicely $Actual.GetType())."
+# v -Equivalence "`$Actual is equivalent to `$null, because it is `$null."
+& (Get-Module Assert) {
+    function c ($a, $e) {
+        Compare-Equivalent -Actual $a -Expected $e -Verbose
+        "`n"
+    }
+
+    function mm ($string) { m "- $string" }
+    function m ($string) { Write-Host -fore Cyan $string}
+m ("-*"*40)
+#mm "nulls"
+#c -a 1 -e $null 
+#c -a $null -e $null 
+
+
+#mm "values"
+
+#mm "bools"
+#m "fixing bool for expected"
+#c -a $false -e 'False' 
+#c -a $true -e 'False' 
+
+#m "fixing bool for actual"
+#c -a 'False' -e $false 
+#c -a 'False' -e $true 
+
+#m compare scriptblocks by content
+# c -a {} -e {} 
+# c -a { "hello" } -e { "hello" }
+
+# c -a { } -e {} 
+# c -a { "hello"} -e { "hello" }
+
+# m "normal boolean comparison"
+c -a $true -e $true 
+c -a $false -e $false 
+c -a $true -e $false 
+c -a $false -e $true 
+c -a "" -e $true 
+c -a 1 -e $true 
+c -a 0 -e $true
+c -a {} -e ""
+c -a "" -e {}
+
+m compare objects 
+
+$expected = [PSCustomObject]@{ 
+    Name = 'Jakub' 
+    Age = 28
+    KnowsPowerShell = $true
+    Languages = 'Czech', 'English' 
+}
+
+$actual = [PSCustomObject]@{ 
+    Name = 'Jkb'
+    KnowsPowerShell = 0
+    Languages = 'Czech', 'English', 'German'
+}
+
+c -a $actual -e $expected
+
+
+}

--- a/VerboseOutput.ps1
+++ b/VerboseOutput.ps1
@@ -12,6 +12,7 @@ Import-module .\Assert.psd1
         "`n"
     }
 
+    
     function mm ($string) { m "- $string" }
     function m ($string) { Write-Host -fore Cyan $string}
 m ("-*"*40)
@@ -49,22 +50,22 @@ m ("-*"*40)
 # c -a {} -e ""
 # c -a "" -e {}
 
-# m compare objects 
+m compare objects 
 
-# $expected = [PSCustomObject]@{ 
-#     Name = 'Jakub' 
-#     Age = 28
-#     KnowsPowerShell = $true
-#     Languages = 'Czech', 'English' 
-# }
+$expected = [PSCustomObject]@{ 
+    Name = 'Jakub' 
+    Age = 28
+    KnowsPowerShell = $true
+    Languages = 'Czech', 'English' 
+}
 
-# $actual = [PSCustomObject]@{ 
-#     Name = 'Jkb'
-#     KnowsPowerShell = 0
-#     Languages = 'Czech', 'English', 'German'
-# }
+$actual = [PSCustomObject]@{ 
+    Name = 'Jkb'
+    KnowsPowerShell = 0
+    Languages = 'Czech', 'English', 'German'
+}
 
-# c -a $actual -e $expected
+c -a $actual -e $expected
 
 # m hashtables 
 # c -a @{} -e @{}
@@ -74,7 +75,11 @@ m ("-*"*40)
 # c -a @{} -e @{Name="Jakub"}
 # c -a @{Name="Jakub"} -e @{Name="Jakub"}
 
-
+# m collections
+# c -a 1 -e @()
+# c -a @() -e @()
+# c -a @(1) -e @()
+# c -a @(1,1) -e @(1,2)
 }
 
 

--- a/VerboseOutput.ps1
+++ b/VerboseOutput.ps1
@@ -52,6 +52,7 @@ m ("-*"*40)
 
 m compare objects 
 
+
 $expected = [PSCustomObject]@{ 
     Name = 'Jakub' 
     Age = 28
@@ -66,7 +67,6 @@ $actual = [PSCustomObject]@{
 }
 
 c -a $actual -e $expected
-
 # m hashtables 
 # c -a @{} -e @{}
 # c -a @() -e @{}

--- a/VerboseOutput.ps1
+++ b/VerboseOutput.ps1
@@ -39,32 +39,42 @@ m ("-*"*40)
 # c -a { "hello"} -e { "hello" }
 
 # m "normal boolean comparison"
-c -a $true -e $true 
-c -a $false -e $false 
-c -a $true -e $false 
-c -a $false -e $true 
-c -a "" -e $true 
-c -a 1 -e $true 
-c -a 0 -e $true
-c -a {} -e ""
-c -a "" -e {}
+# c -a $true -e $true 
+# c -a $false -e $false 
+# c -a $true -e $false 
+# c -a $false -e $true 
+# c -a "" -e $true 
+# c -a 1 -e $true 
+# c -a 0 -e $true
+# c -a {} -e ""
+# c -a "" -e {}
 
-m compare objects 
+# m compare objects 
 
-$expected = [PSCustomObject]@{ 
-    Name = 'Jakub' 
-    Age = 28
-    KnowsPowerShell = $true
-    Languages = 'Czech', 'English' 
+# $expected = [PSCustomObject]@{ 
+#     Name = 'Jakub' 
+#     Age = 28
+#     KnowsPowerShell = $true
+#     Languages = 'Czech', 'English' 
+# }
+
+# $actual = [PSCustomObject]@{ 
+#     Name = 'Jkb'
+#     KnowsPowerShell = 0
+#     Languages = 'Czech', 'English', 'German'
+# }
+
+# c -a $actual -e $expected
+
+# m hashtables 
+# c -a @{} -e @{}
+# c -a @() -e @{}
+
+# c -a @{Name="Jakub"} -e @{}
+# c -a @{} -e @{Name="Jakub"}
+# c -a @{Name="Jakub"} -e @{Name="Jakub"}
+
+
 }
 
-$actual = [PSCustomObject]@{ 
-    Name = 'Jkb'
-    KnowsPowerShell = 0
-    Languages = 'Czech', 'English', 'German'
-}
 
-c -a $actual -e $expected
-
-
-}

--- a/src/Equivalence/Assert-Equivalent.ps1
+++ b/src/Equivalence/Assert-Equivalent.ps1
@@ -93,9 +93,12 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property) {
             for ($a=0; $a -lt $aEnd; $a++) {
                 # we already took this item as equivalent to an item
                 # in the expected collection, skip it
-                if ($taken -contains $a) { continue }
+                if ($taken -contains $a) { 
+                    v "Skipping `$Actual[$a] because it is already taken."
+                    continue }
                 $currentActual = $Actual[$a]
                 # -not, because $null means no differences, and some strings means there are differences
+                v "Comparing `$Actual[$a] to `$Expected[$e] to see if they are equivalent."
                 if (-not (Compare-Equivalent -Expected $currentExpected -Actual $currentActual -Path $Property))
                 {
                     # add the index to the list of taken items so we can skip it
@@ -385,7 +388,7 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property) {
         $actualProperty = $actualProperties | Where { $_.Name -eq $propertyName}
         if (-not $actualProperty)
         {
-            v -Difference "Property '$propertyName` was not found on `$Actual."
+            v -Difference "Property '$propertyName' was not found on `$Actual."
             "Expected has property '$PropertyName' that the other object does not have."
             continue
         }

--- a/src/Equivalence/Assert-Equivalent.ps1
+++ b/src/Equivalence/Assert-Equivalent.ps1
@@ -103,7 +103,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property) {
                     # arrays multiple same items
                     $taken += $a
                     $found = $true
-                    v -Equivalence "`Found equivalent item `$Expected[$e] on `$Actual[$a]."
+                    v -Equivalence "`Found equivalent item for `$Expected[$e] at `$Actual[$a]."
                     # we already found the item we 
                     # can move on to the next item in Exected array
                     break

--- a/src/Equivalence/Assert-Equivalent.ps1
+++ b/src/Equivalence/Assert-Equivalent.ps1
@@ -397,7 +397,7 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property) {
         v -Difference "`$Actual has ($(@($propertiesNotInExpected).Count)) properties that `$Expected does not have: $(Format-Nicely @($propertiesNotInExpected))."
     }
     else {
-        v -Difference "`$Actual has no extra properties that `$Expected does not have."
+        v -Equivalence "`$Actual has no extra properties that `$Expected does not have."
     }
     foreach ($p in $propertiesNotInExpected)
     {

--- a/tst/Equivalence/Assert-Equivalent.Tests.ps1
+++ b/tst/Equivalence/Assert-Equivalent.Tests.ps1
@@ -178,8 +178,16 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Given two collections '<expected>' '<actual>' it compares each value with each value and returns `$null if all of them are equivalent" -TestCases @(
-            @{ Actual = (1,2,3); Expected = (1,2,3)},
+            @{ Actual = (1,2,3); Expected = (1,2,3)}
             @{ Actual = (1,2,3); Expected = (3,2,1)}
+
+            # issue https://github.com/nohwnd/Assert/issues/31
+            @{ Actual = ($null, $null); Expected = ($null, $null) }
+            @{ Actual = ($null, $null, $null); Expected = ($null, $null, $null) }
+            @{ Actual = (1, 1, 1, 1); Expected = (1, 1, 1, 1) }
+            @{ Actual = (1, 2, 2, 1); Expected = (2, 1, 2, 1) }
+            ##
+            
         ) {
             param ($Actual, $Expected)
             Compare-CollectionEquivalent -Actual $Actual -Expected $Expected | Verify-Null


### PR DESCRIPTION
Adds verbose output to Assert-Equivalent and fixes two bugs in collection comparison.

When comparing collections we go through each item in Expected and compare it for equivalence with every item in Actual. When the item is found, we take note of the index in actual so we dont compare them further. This way we are able to compare a: (1,1,2) to e:(1,1,2) as equivalent, but a: (1,1,2), e:(1,2,2) as not equivalent. Without taking the already matched items out of consideration we would be linking one item from expected to multiple items in actual, or vice versa. - but in the loop where this was happening it did not return right after a match was found, so every item in the collection was marked as taken, and none were left for the next iteration. Making the assertion report non-equivalence even though the collections are equivalent. To solve this I simply break out of the loop as soon as I find an item.

Now you might ask why ($null, $null) did not fail then? There was another bug. When deciding whether or not the collections are equivalent I we look at the collection of items that were not found, but in case we did not find a single null, we cast @($null) to bool which is false, so it seems that all items were found (0 items were not found), which is not true. so instead of depending on the rules of coalescing to bool I am taking note that there is some difference when the branch of logic is reached, which results in ($null, $null) failng "correctly" when the above bug is present.


Fix #31 