### PR TITLE
Add Appveyor yml file to run tests against Windows PowerShell 5.1, PowerShell Core on Windows and PowerShell Core on Linux (Ubuntu)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,6 @@ environment:
     PSEdition: Core
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     PSEdition: Desktop
-  - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-    PSEdition: Core
 
 build_script:
   - ps:   if ( $env:PSEdition -eq 'Desktop' ) { ./tst/test.ps1 -CIBuild }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
   - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     PowerShellEdition: PowerShellCore
 
-build_script:
+test_script:
   - ps:   if ( $env:PowerShellEdition -eq 'WindowsPowerShell' ) { ./tst/test.ps1 -CIBuild }
   - pwsh: if ( $env:PowerShellEdition -eq 'PowerShellCore'    ) { ./tst/test.ps1 -CIBuild }
   

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,4 +8,5 @@ environment:
     PowerShellEdition: PowerShellCore
 
 build_script:
-  - pwsh: ./tst/test.ps1 -CIBuild
+  - ps:   if ( $env:PowerShellEdition -eq 'WindowsPowerShell' ) { ./tst/test.ps1 -CIBuild }
+  - pwsh: if ( $env:PowerShellEdition -eq 'PowerShellCore'    ) { ./tst/test.ps1 -CIBuild }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,11 @@
+environment:
+  matrix:
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    PowerShellEdition: PowerShellCore
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    PowerShellEdition: WindowsPowerShell
+  - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+    PowerShellEdition: PowerShellCore
+
+build_script:
+  - pwsh: ./tst/test.ps1 -CIBuild

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,3 +10,6 @@ environment:
 build_script:
   - ps:   if ( $env:PowerShellEdition -eq 'WindowsPowerShell' ) { ./tst/test.ps1 -CIBuild }
   - pwsh: if ( $env:PowerShellEdition -eq 'PowerShellCore'    ) { ./tst/test.ps1 -CIBuild }
+  
+on_finish:
+  -pwsh: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/${env:APPVEYOR_JOB_ID}", (Join-Path $pwd 'TestResults.xml'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,9 +7,9 @@ environment:
   - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     PowerShellEdition: PowerShellCore
 
-test_script:
+build_script:
   - ps:   if ( $env:PowerShellEdition -eq 'WindowsPowerShell' ) { ./tst/test.ps1 -CIBuild }
   - pwsh: if ( $env:PowerShellEdition -eq 'PowerShellCore'    ) { ./tst/test.ps1 -CIBuild }
   
-on_finish:
+after_test:
   -pwsh: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/${env:APPVEYOR_JOB_ID}", (Join-Path $pwd 'TestResults.xml'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,5 @@ environment:
 build_script:
   - ps:   if ( $env:PowerShellEdition -eq 'WindowsPowerShell' ) { ./tst/test.ps1 -CIBuild }
   - pwsh: if ( $env:PowerShellEdition -eq 'PowerShellCore'    ) { ./tst/test.ps1 -CIBuild }
+  - pwsh: Test-Path (Join-Path $pwd 'TestResults.xml'); (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/${env:APPVEYOR_JOB_ID}", (Join-Path $pwd 'TestResults.xml'))
   
-after_test:
-  -pwsh: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/${env:APPVEYOR_JOB_ID}", (Join-Path $pwd 'TestResults.xml'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,14 +1,14 @@
 environment:
   matrix:
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    PowerShellEdition: PowerShellCore
+    PSEdition: Core
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    PowerShellEdition: WindowsPowerShell
+    PSEdition: Desktop
   - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-    PowerShellEdition: PowerShellCore
+    PSEdition: Core
 
 build_script:
-  - ps:   if ( $env:PowerShellEdition -eq 'WindowsPowerShell' ) { ./tst/test.ps1 -CIBuild }
-  - pwsh: if ( $env:PowerShellEdition -eq 'PowerShellCore'    ) { ./tst/test.ps1 -CIBuild }
-  - pwsh: Test-Path (Join-Path $pwd 'TestResults.xml'); (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/${env:APPVEYOR_JOB_ID}", (Join-Path $pwd 'TestResults.xml'))
+  - ps:   if ( $env:PSEdition -eq 'Desktop' ) { ./tst/test.ps1 -CIBuild }
+  - pwsh: if ( $env:PSEdition -eq 'Core'    ) { ./tst/test.ps1 -CIBuild }
+  - pwsh: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/${env:APPVEYOR_JOB_ID}", (Join-Path $PWD 'TestResults.xml'))
   

--- a/tst/test.ps1
+++ b/tst/test.ps1
@@ -43,7 +43,7 @@ try {
 
     "Running all tests from: $path"
     if ($CIBuild) {
-        Invoke-Pester $path -EnableExit
+        Invoke-Pester $path -EnableExit -OutputFormat NUnitXml -OutputFile '..\TestResults.xml'
     }
     else {
         Invoke-Pester $path -Show Summary, Failed


### PR DESCRIPTION
Run build/test script and upload test results in AppVeyor. Just add this repo to AppVeyor and it will work out of the box. [Here](https://ci.appveyor.com/project/bergmeister/assert/builds/20992959) is a build from my fork.

The build that uses Windows PowerShell [here](https://ci.appveyor.com/project/bergmeister/assert/builds/20992959/job/tj1mmpphre2veh4u) exhibits a bug in `Assert` btw:
![image](https://user-images.githubusercontent.com/9250262/49959698-43f7cc80-ff06-11e8-8262-c42b3b95b2bd.png)
