### PR TITLE
Auto-fix PSSA warnings

### DIFF
--- a/Assert.psm1
+++ b/Assert.psm1
@@ -3,15 +3,15 @@ Import-Module $PSScriptRoot/Format/src/Format.psm1 -DisableNameChecking
 
 . $PSScriptRoot/Compatibility/src/Compatibility.ps1
 
-Get-ChildItem -Path $PSScriptRoot/src/ -Recurse -Filter *.ps1 | 
-    foreach { . $_.FullName }
+Get-ChildItem -Path $PSScriptRoot/src/ -Recurse -Filter *.ps1 |
+    ForEach-Object { . $_.FullName }
 
 Export-ModuleMember -Function @(
     'Get-EquivalencyOption'
-    'Assert-Equivalent' 
+    'Assert-Equivalent'
     'Assert-Equal' # ?= ' ?eq
     'Assert-NotEqual' # ?!= ?ne
-    'Assert-Same' # ?=== ?ref ?same 
+    'Assert-Same' # ?=== ?ref ?same
     'Assert-NotSame' # ?!=== ?notref ?notsame
     'Assert-Null' # ?0  ?null
     'Assert-NotNull' # ?!0  ?notnull

--- a/Axiom/src/Verify-AssertionFailed.ps1
+++ b/Axiom/src/Verify-AssertionFailed.ps1
@@ -13,7 +13,7 @@ function Verify-AssertionFailed {
         $assertionExceptionThrown = $true
         $_
     }
-    
+
     if (-not $assertionExceptionThrown) {
         throw [Exception]"An exception of type Assertions.AssertionException was expected but no exception was thrown!"
     }

--- a/Axiom/src/Verify-Equal.ps1
+++ b/Axiom/src/Verify-Equal.ps1
@@ -9,12 +9,12 @@ function Verify-Equal {
     if ($Expected -ne $Actual) {
         $message = "Expected and actual values differ!`n"+
         "Expected: '$Expected'`n"+
-        "Actual  : '$Actual'" 
+        "Actual  : '$Actual'"
         if ($Expected -is [string] -and $Actual -is [string]) {
             $message += "`nExpected length: $($Expected.Length)`nActual length: $($Actual.Length)"
         }
         throw [Exception]$message
     }
-    
+
     $Actual
 }

--- a/Axiom/src/Verify-Like.ps1
+++ b/Axiom/src/Verify-Like.ps1
@@ -9,10 +9,10 @@ function Verify-Like {
     if ($Actual -notlike $Expected) {
         $message = "Expected is not present in Actual!`n"+
         "Expected: '$Expected'`n"+
-        "Actual  : '$Actual'" 
+        "Actual  : '$Actual'"
 
         throw [Exception]$message
     }
-    
+
     $Actual
 }

--- a/Axiom/src/Verify-NotNull.ps1
+++ b/Axiom/src/Verify-NotNull.ps1
@@ -7,6 +7,6 @@ function Verify-NotNull {
     if ($null -eq $Actual) {
         throw [Exception]"Expected not `$null but got `$null."
     }
-    
+
     $Actual
 }

--- a/Axiom/src/Verify-NotSame.ps1
+++ b/Axiom/src/Verify-NotSame.ps1
@@ -9,6 +9,6 @@ function Verify-NotSame {
     if ([object]::ReferenceEquals($Expected, $Actual)) {
         throw [Exception]"Expected the objects to be different instance but they were the same instance."
     }
-    
+
     $Actual
 }

--- a/Axiom/src/Verify-Null.ps1
+++ b/Axiom/src/Verify-Null.ps1
@@ -7,6 +7,6 @@ function Verify-Null {
     if ($null -ne $Actual) {
         throw [Exception]"Expected `$null but got '$Actual'."
     }
-    
+
     $Actual
 }

--- a/Axiom/src/Verify-Same.ps1
+++ b/Axiom/src/Verify-Same.ps1
@@ -9,6 +9,6 @@ function Verify-Same {
     if (-not [object]::ReferenceEquals($Expected, $Actual)) {
         throw [Exception]"Expected the objects to be the same instance but they were not."
     }
-    
+
     $Actual
 }

--- a/Axiom/src/Verify-Throw.ps1
+++ b/Axiom/src/Verify-Throw.ps1
@@ -1,4 +1,4 @@
-function Verify-Throw 
+function Verify-Throw
 {
     param (
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
@@ -14,7 +14,7 @@ function Verify-Throw
         $exceptionThrown = $true
         $_
     }
-    
+
     if (-not $exceptionThrown) {
         throw [Exception]"An exception was expected, but no exception was thrown!"
     }

--- a/Axiom/src/Verify-Type.ps1
+++ b/Axiom/src/Verify-Type.ps1
@@ -9,9 +9,9 @@ function Verify-Type {
     if ($Actual -isnot $Expected) {
         $message = "Expected value to be of type $($Expected.FullName)`n"+
         "Expected: '$($Expected.FullName)'`n"+
-        "Actual  : '$($Actual.GetType().FullName)'" 
+        "Actual  : '$($Actual.GetType().FullName)'"
         throw [Exception]$message
     }
-    
+
     $Actual
 }

--- a/Compatibility/src/Compatibility.ps1
+++ b/Compatibility/src/Compatibility.ps1
@@ -5,37 +5,37 @@ function New-PSObject ([hashtable]$Property) {
 function Invoke-WithContext {
     param(
         [Parameter(Mandatory = $true )]
-        [ScriptBlock] $ScriptBlock, 
+        [ScriptBlock] $ScriptBlock,
         [Parameter(Mandatory = $true)]
         [hashtable] $Variables)
-    
-    # this functions is a psv2 compatible version of 
-    # ScriptBlock InvokeWithContext that is not available 
+
+    # this functions is a psv2 compatible version of
+    # ScriptBlock InvokeWithContext that is not available
     # in that version of PowerShell
 
     # this is what the code below does
     # which in effect sets the context without detaching the
     # scriptblock from the original scope
     # & {
-    #     # context 
-    #     $a = 10 
+    #     # context
+    #     $a = 10
     #     $b = 20
     #     # invoking our original scriptblock
     #     & $sb
     # }
 
     # a similar solution was $SessionState.PSVariable.Set('a', 10)
-    # but that sets the variable for all "scopes" in the current 
+    # but that sets the variable for all "scopes" in the current
     # scope so the value persist after the original has run which
-    # is not correct, 
+    # is not correct,
 
     $scriptBlockWithContext = {
         param($context)
 
-        foreach ($pair in $context.Variables.GetEnumerator()) { 
+        foreach ($pair in $context.Variables.GetEnumerator()) {
             New-Variable -Name $pair.Key -Value $pair.Value
         }
-        
+
         # this cleans up the variable from the session
         # the subexpression outputs the value of the variable
         # and then deletes the variable, so the value is still passed
@@ -64,7 +64,7 @@ function Get-Type ($InputObject) {
     try {
         $ErrorActionPreference = 'Stop'
         # normally this would not ever throw
-        # but in psv2 when datatable is deserialized then 
+        # but in psv2 when datatable is deserialized then
         # [Deserialized.System.Data.DataTable] does not contain
         # .GetType()
         $InputObject.GetType()

--- a/Compatibility/tst/Compatibility.Tests.ps1
+++ b/Compatibility/tst/Compatibility.Tests.ps1
@@ -2,22 +2,22 @@ $here = $MyInvocation.MyCommand.Path | Split-Path
 Import-Module -Force $here/../../Axiom/src/Axiom.psm1 -DisableNameChecking
 . $here/../src/Compatibility.ps1
 
-Describe "New-PSObject" { 
+Describe "New-PSObject" {
     It "Creates a new object of type PSCustomObject" {
-        $hashtable = @{ 
+        $hashtable = @{
             Name = 'Jakub'
         }
 
-        $object = New-PSObject $hashtable 
+        $object = New-PSObject $hashtable
         $object | Verify-Type ([PSCustomObject])
     }
 
     It "Creates a new PSObject with the properties populated" {
-        $hashtable = @{ 
+        $hashtable = @{
             Name = 'Jakub'
         }
 
-        $object = New-PSObject $hashtable 
+        $object = New-PSObject $hashtable
         $object.Name | Verify-Equal $hashtable.Name
     }
 }
@@ -47,37 +47,37 @@ Describe "Test-NullOrWhiteSpace" {
 }
 
 Describe "Invoke-WithContext" {
-    BeforeAll { 
-        Get-Module "Test-Module" | Remove-Module 
+    BeforeAll {
+        Get-Module "Test-Module" | Remove-Module
         $body = {
             $a = "in test module"
             $context = "context"
 
             # all of these are functions returning scriptblocks
-            # so we can test that they remain bounded to the state of 
+            # so we can test that they remain bounded to the state of
             # this module
             function sb1 { { "-$a-" } }
             function sb2 { { "-$a- -$b-" } }
             function sb3 { { "-$context- -$a-" } }
         }
-        New-Module -Name "Test-Module" -ScriptBlock $body | Import-Module 
+        New-Module -Name "Test-Module" -ScriptBlock $body | Import-Module
     }
 
-    AfterAll { 
-        Get-Module "Test-Module" | Remove-Module 
+    AfterAll {
+        Get-Module "Test-Module" | Remove-Module
     }
 
     It "Keeps the scriptblock attached to the original scope" {
-        # we define variable $a here and in the module, and we must 
+        # we define variable $a here and in the module, and we must
         # resolve $a to the value in the module, not to the local value
         # or null
         $a = 100
-        Invoke-WithContext -ScriptBlock (sb1) -Variables @{} | 
+        Invoke-WithContext -ScriptBlock (sb1) -Variables @{} |
             Verify-Equal "-in test module-"
     }
 
     It "Injects variable `$b into the scope while keeping `$a attached to the module scope" {
-        Invoke-WithContext -ScriptBlock (sb2) -Variables @{ b = 'injected' } | 
+        Invoke-WithContext -ScriptBlock (sb2) -Variables @{ b = 'injected' } |
             Verify-Equal "-in test module- -injected-"
     }
 
@@ -85,12 +85,12 @@ Describe "Invoke-WithContext" {
         # internally we wrap the call in something like
         # & {
         #     param($context)
-        #     & $context.ScriptBlock 
+        #     & $context.ScriptBlock
         # }
         # and we need to make sure that the `$context variable
         # will not be seen by the original scriptblock to avoid
         # naming conflicts
-        Invoke-WithContext -ScriptBlock (sb3) -Variables @{} | 
+        Invoke-WithContext -ScriptBlock (sb3) -Variables @{} |
             Verify-Equal "-context- -in test module-"
     }
 }

--- a/Format/tst/Format.Tests.ps1
+++ b/Format/tst/Format.Tests.ps1
@@ -5,39 +5,39 @@ Import-Module $here/../src/Format.psm1 -Force
 . $here/../../Compatibility/src/Compatibility.ps1
 
 Add-Type -TypeDefinition '
-namespace Assertions.TestType { 
-    public class Person { 
+namespace Assertions.TestType {
+    public class Person {
         // powershell v2 mandates fully implemented properties
         string _name;
         int _age;
-        public string Name { get { return _name; } set { _name = value; } } 
+        public string Name { get { return _name; } set { _name = value; } }
         public int Age { get { return _age; } set { _age = value; } }
     }
 }'
-Describe "Format-Collection" { 
+Describe "Format-Collection" {
     It "Formats collection of values '<value>' to '<expected>' using the default separator" -TestCases @(
         @{ Value = (1, 2, 3); Expected = "1, 2, 3" }
-    ) { 
+    ) {
         param ($Value, $Expected)
         Format-Collection -Value $Value | Verify-Equal $Expected
     }
 
     It "Formats collection of values '<value>' to '<expected>' using the default separator" -TestCases @(
         @{ Value = (1, 2, 3); Expected = "1, 2, 3" }
-    ) { 
+    ) {
         param ($Value, $Expected)
         Format-Collection -Value $Value | Verify-Equal $Expected
     }
 }
 
-Describe "Format-Number" { 
+Describe "Format-Number" {
     It "Formats number to use . separator (tests anything only on non-english systems --todo)" -TestCases @(
         @{ Value = 1.1; },
         @{ Value = [double] 1.1; },
         @{ Value = [float] 1.1; },
         @{ Value = [single] 1.1; },
         @{ Value = [decimal] 1.1; }
-    ) { 
+    ) {
         param ($Value)
         Format-Number -Value $Value | Verify-Equal "1.1"
     }
@@ -47,25 +47,25 @@ Describe "Format-Object" {
     It "Formats object '<value>' to '<expected>'" -TestCases @(
         @{ Value = (New-PSObject @{Name = 'Jakub'; Age = 28}); Expected = "PSObject{Age=28; Name=Jakub}"},
         @{ Value = (New-Object -Type Assertions.TestType.Person -Property @{Name = 'Jakub'; Age = 28}); Expected = "Assertions.TestType.Person{Age=28; Name=Jakub}"}
-    ) { 
+    ) {
         param ($Value, $Expected)
         Format-Object -Value $Value | Verify-Equal $Expected
     }
 
     It "Formats object '<value>' with selected properties '<selectedProperties>' to '<expected>'" -TestCases @(
         @{ Value = (New-PSObject @{Name = 'Jakub'; Age = 28}); SelectedProperties = "Age"; Expected = "PSObject{Age=28}"},
-        @{ 
+        @{
             Value              = (New-Object -Type Assertions.TestType.Person -Property @{Name = 'Jakub'; Age = 28})
             SelectedProperties = 'Name'
             Expected           = "Assertions.TestType.Person{Name=Jakub}"
         }
-    ) { 
+    ) {
         param ($Value, $SelectedProperties, $Expected)
         Format-Object -Value $Value -Property $SelectedProperties | Verify-Equal $Expected
     }
 
-    It "Formats current process with selected properties Name and Id correctly" { 
-        # this used to be a normal unit test but Idle process does not exist 
+    It "Formats current process with selected properties Name and Id correctly" {
+        # this used to be a normal unit test but Idle process does not exist
         # cross platform so we use the current process, which can also have
         # different names among powershell versions
         $process = Get-Process -PID $PID
@@ -88,19 +88,19 @@ Describe "Format-Boolean" {
     }
 }
 
-Describe "Format-Null" { 
+Describe "Format-Null" {
     It "Formats null to '`$null'" {
         Format-Null | Verify-Equal '$null'
     }
 }
 
-Describe "Format-ScriptBlock" { 
+Describe "Format-ScriptBlock" {
     It "Formats scriptblock as string with curly braces" {
         Format-ScriptBlock -Value {abc} | Verify-Equal '{abc}'
     }
 }
 
-Describe "Format-Hashtable" { 
+Describe "Format-Hashtable" {
     It "Formats empty hashtable as @{}" {
         Format-Hashtable @{} | Verify-Equal '@{}'
     }
@@ -115,7 +115,7 @@ Describe "Format-Hashtable" {
     }
 }
 
-Describe "Format-Dictionary" { 
+Describe "Format-Dictionary" {
     It "Formats empty dictionary as @{}" {
         Format-Dictionary (New-Dictionary @{}) | Verify-Equal 'Dictionary{}'
     }
@@ -144,7 +144,7 @@ Describe "Format-Nicely" {
         @{ Value = (New-Object -Type Assertions.TestType.Person -Property @{Name = 'Jakub'; Age = 28}); Expected = "Assertions.TestType.Person{Age=28; Name=Jakub}"}
         @{ Value = @{Name = 'Jakub'; Age = 28}; Expected = '@{Age=28; Name=Jakub}' }
         @{ Value = New-Dictionary @{Age = 28; Name = 'Jakub'}; Expected = 'Dictionary{Age=28; Name=Jakub}' }
-    ) { 
+    ) {
         param($Value, $Expected)
         Format-Nicely -Value $Value | Verify-Equal $Expected
     }
@@ -173,7 +173,7 @@ Describe "Format-Type" {
         Format-Type -Value $Value | Verify-Equal $Expected
     }
 }
- 
+
 
 Describe "Get-ShortType" {
     It "Given '<value>' it returns the correct shortened type name '<expected>'" -TestCases @(

--- a/TypeClass/tst/TypeClass.Tests.ps1
+++ b/TypeClass/tst/TypeClass.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Is-Value" {
         @{ Value = @("abc")},
         @{ Value = @(1)},
         @{ Value = {abc}}
-    ) {  
+    ) {
         param($Value)
         Is-Value -Value $Value | Verify-True
     }
@@ -27,7 +27,7 @@ Describe "Is-Value" {
         @{ Value = @{} },
         @{ Value = [type] },
         @{ Value = (New-Object -TypeName Diagnostics.Process) }
-    ) {  
+    ) {
         param($Value)
         Is-Value -Value $Value | Verify-False
     }
@@ -35,31 +35,31 @@ Describe "Is-Value" {
 
 #number
 
-Describe "Is-DecimalNumber" { 
+Describe "Is-DecimalNumber" {
     It "Given a number it returns `$true" -TestCases @(
         @{ Value = 1.1; },
         @{ Value = [double] 1.1; },
         @{ Value = [float] 1.1; },
         @{ Value = [single] 1.1; },
         @{ Value = [decimal] 1.1; }
-    ) { 
+    ) {
         param ($Value)
         Is-DecimalNumber -Value $Value | Verify-True
     }
 
-    It "Given a string it returns `$false" { 
+    It "Given a string it returns `$false" {
         Is-DecimalNumber -Value "abc" | Verify-False
     }
 }
 
-Describe "Is-ScriptBlock" { 
+Describe "Is-ScriptBlock" {
     It "Given a scriptblock '{<value>}' it returns `$true" -TestCases @(
         @{ Value = {} },
         @{ Value = {abc} },
         @{ Value = { Get-Process -Name Idle } }
     ) {
         param ($Value)
-        Is-ScriptBlock -Value $Value | Verify-True 
+        Is-ScriptBlock -Value $Value | Verify-True
     }
 
     It "Given a value '<value>' that is not a scriptblock it returns `$false" -TestCases @(
@@ -69,16 +69,16 @@ Describe "Is-ScriptBlock" {
         @{ Value = [Type] }
     ) {
         param ($Value)
-        Is-ScriptBlock -Value $Value | Verify-False 
+        Is-ScriptBlock -Value $Value | Verify-False
     }
 }
 
 # -- KeyValue collections
-Describe "Is-Hashtable" { 
+Describe "Is-Hashtable" {
     It "Given hashtable '<value>' it returns `$true" -TestCases @(
         @{Value = @{} }
         @{Value = @{Name="Jakub"} }
-    ) { 
+    ) {
         param($Value)
 
         Is-Hashtable -Value $Value | Verify-True
@@ -87,18 +87,18 @@ Describe "Is-Hashtable" {
     It "Given a value '<value>' which is not a hashtable it returns `$false" -TestCases @(
         @{ Value = "Jakub" }
         @{ Value = 1..4 }
-    ) { 
+    ) {
         param ($Value)
 
         Is-Hashtable -Value $Value | Verify-False
     }
 }
 
-Describe "Is-Dictionary" { 
+Describe "Is-Dictionary" {
     It "Given dictionary '<value>' it returns `$true" -TestCases @(
         @{ Value = New-Object "Collections.Generic.Dictionary[string,object]" }
         @{ Value= New-Dictionary @{Name="Jakub"} }
-    ) { 
+    ) {
         param($Value)
 
         Is-Dictionary -Value $Value | Verify-True
@@ -107,7 +107,7 @@ Describe "Is-Dictionary" {
     It "Given a value '<value>' which is not a dictionary it returns `$false" -TestCases @(
         @{ Value = "Jakub" }
         @{ Value = 1..4 }
-    ) { 
+    ) {
         param ($Value)
 
         Is-Dictionary -Value $Value | Verify-False
@@ -120,13 +120,13 @@ Describe "Is-Collection" {
     It "Given a collection '<value>' of type '<type>' it returns `$true" -TestCases @(
         @{ Value = @() }
         @{ Value = 1,2,3 }
-        # powershell v2 requires the coma before the number to make it 
+        # powershell v2 requires the coma before the number to make it
         # array that is convertible to a list
         @{ Value = [System.Collections.Generic.List[int]] ,1 }
         @{ Value = [System.Collections.Generic.List[decimal]] ,2 }
         @{ Value = [Collections.Generic.List[Int]] [int[]](1,2,3) }
         @{ Value = [Collections.Generic.List[Int]] [int[]](1,2,3) }
-        # @ forces this to be an array even if there are 
+        # @ forces this to be an array even if there are
         # only 1 processes, like when you run in docker
         @{ Value = @(Get-Process) }
     ) {
@@ -136,7 +136,7 @@ Describe "Is-Collection" {
 
     It "Given an object '<value>' of type '<type>' that is not a collection it returns `$false" -TestCases @(
         @{ Value = $null }
-        
+
         @{ Value = [char] 'a' }
         @{ Value = "a" }
 

--- a/doc/readme/compare-objects.ps1
+++ b/doc/readme/compare-objects.ps1
@@ -1,13 +1,13 @@
 Import-Module ./assert.psd1  -Force
 
-$expected = [PSCustomObject]@{ 
-    Name = 'Jakub' 
+$expected = [PSCustomObject]@{
+    Name = 'Jakub'
     Age = 28
-    Languages = 'Czech', 'English' 
+    Languages = 'Czech', 'English'
 }
 
-$actual = [PSCustomObject]@{ 
-    Name = 'Jkb' 
+$actual = [PSCustomObject]@{
+    Name = 'Jkb'
     Languages = 'Czech', 'English', 'German'
 }
 

--- a/doc/readme/custom-messages.ps1
+++ b/doc/readme/custom-messages.ps1
@@ -6,15 +6,15 @@ function Get-ActiveComputers () {
         @{ HostName = "WKA5" }
     )
 
-    $c | % {[PSCustomObject]$_}
+    $c | ForEach-Object {[PSCustomObject]$_}
 }
 
 Describe "Active computers" {
     It "All our computer names start with WKS*" {
-        Get-ActiveComputers | 
-            Select-Object -ExpandProperty HostName | 
+        Get-ActiveComputers |
+            Select-Object -ExpandProperty HostName |
             Assert-All {$_ -like 'WKS*'} -CustomMessage `
-            "<actualFilteredCount> computers do not start with WKS*: 
+            "<actualFilteredCount> computers do not start with WKS*:
             '<actualFiltered>'"
     }
 }

--- a/doc/readme/pretty-print.ps1
+++ b/doc/readme/pretty-print.ps1
@@ -2,8 +2,8 @@
 
 function Format-Nicely ($o){ &$f $o }
 
-Format-Nicely $null 
-Format-Nicely $false 
+Format-Nicely $null
+Format-Nicely $false
 Format-Nicely $true
 Format-Nicely ( @{ Name = 'Jakub' } )
 Format-Nicely ( [PSCustomObject]@{ Name = 'Jakub' } )

--- a/doc/readme/specialized-assertions.ps1
+++ b/doc/readme/specialized-assertions.ps1
@@ -1,5 +1,5 @@
 "Hello" | Assert-Equal -Expected "hello"
 
-"Hello" | Assert-StringEqual -Expected "Hello" -CaseSensitive 
+"Hello" | Assert-StringEqual -Expected "Hello" -CaseSensitive
 
 "Hello" | Assert-StringEqual -Expected "hello " -IgnoreWhitespace

--- a/doc/readme/words.ps1
+++ b/doc/readme/words.ps1
@@ -1,8 +1,8 @@
 Import-Module ./Assert.psd1
 
-function Get-Word ([string]$Filter) 
+function Get-Word ([string]$Filter)
 {
-    $words = @( 
+    $words = @(
         'apple'
         'alphabet'
         'armadillo'
@@ -16,6 +16,6 @@ function Get-Word ([string]$Filter)
 
 Describe "Get-Word" {
     It "Only returns words starting with 'a'" {
-        Get-Word -Filter 'a*' | Assert-All { $_ -like 'a*' }   
+        Get-Word -Filter 'a*' | Assert-All { $_ -like 'a*' }
     }
 }

--- a/src/Boolean/Assert-False.ps1
+++ b/src/Boolean/Assert-False.ps1
@@ -1,13 +1,13 @@
 function Assert-False {
     param (
         [Parameter(ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ($Actual) 
-    { 
+    if ($Actual)
+    {
         $Message = Get-AssertionMessage -Expected $false -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <actualType> '<actual>' to be <expectedType> '<expected>' or falsy value 0, """", `$null, @()."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/Boolean/Assert-True.ps1
+++ b/src/Boolean/Assert-True.ps1
@@ -1,13 +1,13 @@
 function Assert-True{
     param (
         [Parameter(ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if (-not $Actual) 
-    { 
+    if (-not $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $true -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <actualType> '<actual>' to be <expectedType> '<expected>' or truthy value."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/Collection/Assert-All.ps1
+++ b/src/Collection/Assert-All.ps1
@@ -2,19 +2,19 @@ function Assert-All {
     [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline=$true, Position=1)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0, Mandatory=$true)]
         [scriptblock]$FilterScript,
         [String]$CustomMessage
     )
-    
+
 
     $Expected = $FilterScript
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
     # we are jumping between modules so I need to explicitly pass the _ variable
     # simply using '&' won't work
     # see: https://blogs.msdn.microsoft.com/sergey_babkins_blog/2014/10/30/calling-the-script-blocks-in-powershell/
-    $actualFiltered = $Actual | foreach { 
+    $actualFiltered = $Actual | ForEach-Object {
         # powershell v4 code where we have InvokeWithContext available
         # $underscore = Get-Variable _
         # $pass = $FilterScript.InvokeWithContext($null, $underscore, $null)
@@ -22,14 +22,14 @@ function Assert-All {
         # polyfill for PowerShell v2
         $PSCmdlet.SessionState.PSVariable.Set("_", $_)
         $pass = & $FilterScript
-        
-    
+
+
         if (-not $pass) { $_ }
     }
 
     if ($actualFiltered)
-    { 
-        $data = @{ 
+    {
+        $data = @{
             actualFiltered = $actualFiltered
             actualFilteredCount = @($actualFiltered).Count
         }

--- a/src/Collection/Assert-Any.ps1
+++ b/src/Collection/Assert-Any.ps1
@@ -1,16 +1,16 @@
 function Assert-Any {
     param (
         [Parameter(ValueFromPipeline=$true, Position=1)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0, Mandatory=$true)]
         [scriptblock]$FilterScript,
         [String]$CustomMessage
     )
-    
+
     $Expected = $FilterScript
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
     if (-not ($Actual | Where-Object -FilterScript $FilterScript))
-    { 
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected at least one item in collection '<actual>' to pass filter '<expected>', but none of the items passed the filter."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/Collection/Assert-Contain.ps1
+++ b/src/Collection/Assert-Contain.ps1
@@ -1,15 +1,15 @@
 function Assert-Contain {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ($Actual -notcontains $Expected) 
-    { 
+    if ($Actual -notcontains $Expected)
+    {
         $type = [string]$Expected
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <expectedType> '<expected>' to be present in collection '<actual>', but it was not there."
         throw [Assertions.AssertionException]$Message

--- a/src/Collection/Assert-NotContain.ps1
+++ b/src/Collection/Assert-NotContain.ps1
@@ -1,15 +1,15 @@
 function Assert-NotContain {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ($Actual -contains $Expected) 
-    { 
+    if ($Actual -contains $Expected)
+    {
         $type = [string]$Expected
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <expectedType> '<expected>' to not be present in collection '<actual>', but it was there."
         throw [Assertions.AssertionException]$Message

--- a/src/Common/Collect-Input.ps1
+++ b/src/Common/Collect-Input.ps1
@@ -1,4 +1,4 @@
-function Collect-Input ($ParameterInput, $PipelineInput) 
+function Collect-Input ($ParameterInput, $PipelineInput)
 {
     #source: http://www.powertheshell.com/input_psv3/
     $collectedInput = @($PipelineInput)
@@ -7,7 +7,7 @@ function Collect-Input ($ParameterInput, $PipelineInput)
     if ($isInPipeline) {
         $collectedInput
     }
-    else 
+    else
     {
         $ParameterInput
     }

--- a/src/Common/Get-AssertionMessage.ps1
+++ b/src/Common/Get-AssertionMessage.ps1
@@ -1,10 +1,10 @@
-function Get-AssertionMessage ($Expected, $Actual, $Option, [hashtable]$Data = @{}, $CustomMessage, $DefaultMessage, [switch]$Pretty) 
+function Get-AssertionMessage ($Expected, $Actual, $Option, [hashtable]$Data = @{}, $CustomMessage, $DefaultMessage, [switch]$Pretty)
 {
     if (-not $CustomMessage)
     {
         $CustomMessage = $DefaultMessage
     }
-    
+
     $expectedFormatted = Format-Nicely -Value $Expected -Pretty:$Pretty
     $actualFormatted = Format-Nicely -Value $Actual -Pretty:$Pretty
 
@@ -16,7 +16,7 @@ function Get-AssertionMessage ($Expected, $Actual, $Option, [hashtable]$Data = @
         }
         else {
             if ($Pretty) {
-                $optionMessage = "Used options:$($Option | foreach { "`n$_" })."
+                $optionMessage = "Used options:$($Option | ForEach-Object { "`n$_" })."
             }
         }
     }
@@ -36,8 +36,8 @@ function Get-AssertionMessage ($Expected, $Actual, $Option, [hashtable]$Data = @
     if (-not $Pretty) {
         $CustomMessage
     }
-    else 
+    else
     {
-        $CustomMessage + "`n`n" 
+        $CustomMessage + "`n`n"
     }
 }

--- a/src/Common/Get-CustomFailureMessage.ps1
+++ b/src/Common/Get-CustomFailureMessage.ps1
@@ -1,4 +1,4 @@
-function Get-CustomFailureMessage ($CustomMessage, $Expected, $Actual) 
+function Get-CustomFailureMessage ($CustomMessage, $Expected, $Actual)
 {
     $formatted = $CustomMessage -f $Expected, $Actual
     $tokensReplaced = $formatted -replace '<expected>', $Expected -replace '<actual>', $Actual

--- a/src/Equivalence/Assert-Equivalent.ps1
+++ b/src/Equivalence/Assert-Equivalent.ps1
@@ -58,7 +58,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
 
     if (-not (Is-Collection -Value $Actual))
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not a collection it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
+        v -Difference "`$Actual is not a collection it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
         $expectedFormatted = Format-Collection -Value $Expected
         $expectedLength = $expected.Length
         $actualFormatted = Format-Nicely -Value $actual
@@ -66,19 +66,19 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
     }
 
     if (-not (Is-CollectionSize -Expected $Expected -Actual $Actual)) {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual does not have the same size ($($Actual.Length)) as `$Expected ($($Expected.Length)) so they are not equivalent."
+        v -Difference "`$Actual does not have the same size ($($Actual.Length)) as `$Expected ($($Expected.Length)) so they are not equivalent."
         return Get-CollectionSizeNotTheSameMessage -Expected $Expected -Actual $Actual -Property $Property
     }
 
     $eEnd = if ($Expected.Length -is [int]) {$Expected.Length} else {$Expected.Count}
     $aEnd = if ($Actual.Length -is [int]) {$Actual.Length} else {$Actual.Count}
-    C:\Program Files (x86)\vim\vim80\vim.exe "Comparing items in collection, `$Expected has lenght $eEnd, `$Actual has length $aEnd."
+    v "Comparing items in collection, `$Expected has lenght $eEnd, `$Actual has length $aEnd."
     $taken = @()
     $notFound = @()
     $anyDifferent = $false
     for ($e=0; $e -lt $eEnd; $e++) {
         # todo: retest strict order
-        C:\Program Files (x86)\vim\vim80\vim.exe "`nSearching for `$Expected[$e]:"
+        v "`nSearching for `$Expected[$e]:"
         $currentExpected = $Expected[$e]
         $found = $false
         if ($StrictOrder) {
@@ -87,7 +87,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
             {
                 $taken += $e
                 $found = $true
-                C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`Found `$Expected[$e]."
+                v -Equivalence "`Found `$Expected[$e]."
             }
         }
         else {
@@ -95,11 +95,11 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
                 # we already took this item as equivalent to an item
                 # in the expected collection, skip it
                 if ($taken -contains $a) {
-                    C:\Program Files (x86)\vim\vim80\vim.exe "Skipping `$Actual[$a] because it is already taken."
+                    v "Skipping `$Actual[$a] because it is already taken."
                     continue }
                 $currentActual = $Actual[$a]
                 # -not, because $null means no differences, and some strings means there are differences
-                C:\Program Files (x86)\vim\vim80\vim.exe "Comparing `$Actual[$a] to `$Expected[$e] to see if they are equivalent."
+                v "Comparing `$Actual[$a] to `$Expected[$e] to see if they are equivalent."
                 if (-not (Compare-Equivalent -Expected $currentExpected -Actual $currentActual -Path $Property -Options $Options))
                 {
                     # add the index to the list of taken items so we can skip it
@@ -107,7 +107,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
                     # arrays multiple same items
                     $taken += $a
                     $found = $true
-                    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`Found equivalent item for `$Expected[$e] at `$Actual[$a]."
+                    v -Equivalence "`Found equivalent item for `$Expected[$e] at `$Actual[$a]."
                     # we already found the item we
                     # can move on to the next item in Exected array
                     break
@@ -116,7 +116,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
         }
         if (-not $found)
         {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual does not contain `$Expected[$e]."
+            v -Difference "`$Actual does not contain `$Expected[$e]."
             $anyDifferent = $true
             $notFound += $currentExpected
         }
@@ -127,7 +127,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
     # @($null) which evaluates to false, even though
     # there was a single item that we did not find
     if ($anyDifferent) {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual and `$Expected arrays are not equivalent."
+        v -Difference "`$Actual and `$Expected arrays are not equivalent."
         $Expected = Format-Nicely -Value $Expected
         $Actual = Format-Nicely -Value $Actual
         $notFoundFormatted = Format-Nicely -Value ( $notFound | ForEach-Object { Format-Nicely -Value $_ } )
@@ -135,7 +135,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
         $propertyMessage = if ($Property) {" in property $Property which is"}
         return "Expected collection$propertyMessage '$Expected' to be equivalent to '$Actual' but some values were missing: '$notFoundFormatted'."
     }
-    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual and `$Expected arrays are equivalent."
+    v -Equivalence "`$Actual and `$Expected arrays are equivalent."
 }
 
 function Compare-DataTableEquivalent ($Expected, $Actual, $Property, $Options) {
@@ -204,31 +204,31 @@ function Compare-ValueEquivalent ($Actual, $Expected, $Property, $Options) {
     if (($null -eq $Options) -or
         ($null -eq $Options.Comparator) -or
         ("Equivalency" -eq $Options.Comparator)) {
-        C:\Program Files (x86)\vim\vim80\vim.exe "Equivalency comparator is used, values will be compared for equivalency."
+        v "Equivalency comparator is used, values will be compared for equivalency."
         # fix that string 'false' becomes $true boolean
         if ($Actual -is [Bool] -and $Expected -is [string] -and "$Expected" -eq 'False')
         {
-            C:\Program Files (x86)\vim\vim80\vim.exe "`$Actual is a boolean, and `$Expected is a 'False' string, which we consider equivalent to boolean `$false. Setting `$Expected to `$false."
+            v "`$Actual is a boolean, and `$Expected is a 'False' string, which we consider equivalent to boolean `$false. Setting `$Expected to `$false."
             $Expected = $false
             if ($Expected -ne $Actual)
             {
-                C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
+                v -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
                 return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Property -Options $Options
             }
-            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
+            v -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
             return
         }
 
         if ($Expected -is [Bool] -and $Actual -is [string] -and "$Actual" -eq 'False')
         {
-            C:\Program Files (x86)\vim\vim80\vim.exe "`$Actual is a 'False' string, which we consider equivalent to boolean `$false. `$Expected is a boolean. Setting `$Actual to `$false."
+            v "`$Actual is a 'False' string, which we consider equivalent to boolean `$false. `$Expected is a boolean. Setting `$Actual to `$false."
             $Actual = $false
             if ($Expected -ne $Actual)
             {
-                C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
+                v -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
                 return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Property -Options $Options
             }
-            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
+            v -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
             return
         }
 
@@ -236,33 +236,33 @@ function Compare-ValueEquivalent ($Actual, $Expected, $Property, $Options) {
         if (Is-ScriptBlock -Value $Expected)
         {
             # todo: compare by equivalency like strings?
-            C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a ScriptBlock, scriptblocks are considered equivalent when their content is equal. Converting `$Expected to string."
+            v "`$Expected is a ScriptBlock, scriptblocks are considered equivalent when their content is equal. Converting `$Expected to string."
             #forcing scriptblock to serialize to string and then comparing that
             if ("$Expected" -ne $Actual)
             {
                 # todo: difference on index?
-                C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to `$Expected because their contents differ."
+                v -Difference "`$Actual is not equivalent to `$Expected because their contents differ."
                 return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Path -Options $Options
             }
-            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to `$Expected because their contents are equal."
+            v -Equivalence "`$Actual is equivalent to `$Expected because their contents are equal."
             return
         }
     }
     else
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe "Equality comparator is used, values will be compared for equality."
+        v "Equality comparator is used, values will be compared for equality."
     }
 
-    C:\Program Files (x86)\vim\vim80\vim.exe "Comparing values as $(Format-Nicely (Get-Type $Expected)) because `$Expected has that type."
+    v "Comparing values as $(Format-Nicely (Get-Type $Expected)) because `$Expected has that type."
     # todo: shorter messages when both sides have the same type (do not compare by using -is, instead query the type and compare it) because -is is true even for parent types
     $type = Get-Type $Expected
     $coalescedActual = $Actual -as $type
     if ($Expected -ne $Actual)
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual), and $(Format-Nicely $Actual) coalesced to $(Format-Nicely $type) is $(Format-Nicely $coalescedActual)."
+        v -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual), and $(Format-Nicely $Actual) coalesced to $(Format-Nicely $type) is $(Format-Nicely $coalescedActual)."
         return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Property -Options $Options
     }
-    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual), and $(Format-Nicely $Actual) coalesced to $(Format-Nicely $type) is $(Format-Nicely $coalescedActual)."
+    v -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual), and $(Format-Nicely $Actual) coalesced to $(Format-Nicely $type) is $(Format-Nicely $coalescedActual)."
 }
 
 function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
@@ -273,7 +273,7 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
 
     if (-not (Is-Hashtable -Value $Actual))
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not a hashtable it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
+        v -Difference "`$Actual is not a hashtable it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected hashtable '$expectedFormatted', but got '$actualFormatted'."
@@ -284,7 +284,7 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
     $actualKeys = $Actual.Keys
     $expectedKeys = $Expected.Keys
 
-    C:\Program Files (x86)\vim\vim80\vim.exe "`Comparing all ($($expectedKeys.Count)) keys from `$Expected to keys in `$Actual."
+    v "`Comparing all ($($expectedKeys.Count)) keys from `$Expected to keys in `$Actual."
     $result = @()
     foreach ($k in $expectedKeys)
     {
@@ -295,14 +295,14 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
         $actualHasKey = $actualKeys -contains $k
         if (-not $actualHasKey)
         {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is missing key '$k'."
+            v -Difference "`$Actual is missing key '$k'."
             $result += "Expected has key '$k' that the other object does not have."
             continue
         }
 
         $expectedValue = $Expected[$k]
         $actualValue = $Actual[$k]
-        C:\Program Files (x86)\vim\vim80\vim.exe "Both `$Actual and `$Expected have key '$k', comparing thier contents."
+        v "Both `$Actual and `$Expected have key '$k', comparing thier contents."
         $result += Compare-Equivalent -Expected $expectedValue -Actual $actualValue -Path "$Property.$k" -Options $Options
     }
 
@@ -314,10 +314,10 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
 
         # fix for powershell v2 where foreach goes once over null
         if ($filteredKeysNotInExpected | Where-Object { $_ }) {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual has $($filteredKeysNotInExpected.Count) keys that were not found on `$Expected: $(Format-Nicely @($filteredKeysNotInExpected))."
+            v -Difference "`$Actual has $($filteredKeysNotInExpected.Count) keys that were not found on `$Expected: $(Format-Nicely @($filteredKeysNotInExpected))."
         }
         else {
-            C:\Program Files (x86)\vim\vim80\vim.exe "`$Actual has no keys that we did not find on `$Expected."
+            v "`$Actual has no keys that we did not find on `$Expected."
         }
 
         foreach ($k in $filteredKeysNotInExpected | Where-Object { $_ })
@@ -328,13 +328,13 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
 
     if ($result | Where-Object { $_ })
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "Hashtables `$Actual and `$Expected are not equivalent."
+        v -Difference "Hashtables `$Actual and `$Expected are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected hashtable '$expectedFormatted', but got '$actualFormatted'.`n$($result -join "`n")"
     }
 
-    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "Hastables `$Actual and `$Expected are equivalent."
+    v -Equivalence "Hastables `$Actual and `$Expected are equivalent."
 }
 
 function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) {
@@ -345,7 +345,7 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
 
     if (-not (Is-Dictionary -Value $Actual))
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not a dictionary it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
+        v -Difference "`$Actual is not a dictionary it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected dictionary '$expectedFormatted', but got '$actualFormatted'."
@@ -356,7 +356,7 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
     $actualKeys = $Actual.Keys
     $expectedKeys = $Expected.Keys
 
-    C:\Program Files (x86)\vim\vim80\vim.exe "`Comparing all ($($expectedKeys.Count)) keys from `$Expected to keys in `$Actual."
+    v "`Comparing all ($($expectedKeys.Count)) keys from `$Expected to keys in `$Actual."
     $result = @()
     foreach ($k in $expectedKeys)
     {
@@ -367,14 +367,14 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
         $actualHasKey = $actualKeys -contains $k
         if (-not $actualHasKey)
         {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is missing key '$k'."
+            v -Difference "`$Actual is missing key '$k'."
             $result += "Expected has key '$k' that the other object does not have."
             continue
         }
 
         $expectedValue = $Expected[$k]
         $actualValue = $Actual[$k]
-        C:\Program Files (x86)\vim\vim80\vim.exe "Both `$Actual and `$Expected have key '$k', comparing thier contents."
+        v "Both `$Actual and `$Expected have key '$k', comparing thier contents."
         $result += Compare-Equivalent -Expected $expectedValue -Actual $actualValue -Path "$Property.$k" -Options $Options
     }
     if (!$Options.ExcludePathsNotOnExpected) {
@@ -384,10 +384,10 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
 
         # fix for powershell v2 where foreach goes once over null
         if ($filteredKeysNotInExpected | Where-Object { $_ }) {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual has $($filteredKeysNotInExpected.Count) keys that were not found on `$Expected: $(Format-Nicely @($filteredKeysNotInExpected))."
+            v -Difference "`$Actual has $($filteredKeysNotInExpected.Count) keys that were not found on `$Expected: $(Format-Nicely @($filteredKeysNotInExpected))."
         }
         else {
-            C:\Program Files (x86)\vim\vim80\vim.exe "`$Actual has no keys that we did not find on `$Expected."
+            v "`$Actual has no keys that we did not find on `$Expected."
         }
 
         foreach ($k in $filteredKeysNotInExpected | Where-Object { $_ })
@@ -398,12 +398,12 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
 
     if ($result)
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "Dictionaries `$Actual and `$Expected are not equivalent."
+        v -Difference "Dictionaries `$Actual and `$Expected are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected dictionary '$expectedFormatted', but got '$actualFormatted'.`n$($result -join "`n")"
     }
-    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "Dictionaries `$Actual and `$Expected are equivalent."
+    v -Equivalence "Dictionaries `$Actual and `$Expected are equivalent."
 }
 
 function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
@@ -414,7 +414,7 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
     }
 
     if (-not (Is-Object -Value $Actual)) {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not an object it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
+        v -Difference "`$Actual is not an object it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected object '$expectedFormatted', but got '$actualFormatted'."
@@ -423,7 +423,7 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
     $actualProperties = $Actual.PsObject.Properties
     $expectedProperties = $Expected.PsObject.Properties
 
-    C:\Program Files (x86)\vim\vim80\vim.exe "Comparing ($(@($expectedProperties).Count)) properties of `$Expected to `$Actual."
+    v "Comparing ($(@($expectedProperties).Count)) properties of `$Expected to `$Actual."
     foreach ($p in $expectedProperties)
     {
         if (-not (Test-IncludedPath -PathSelector Property -InputObject $p -Options $Options -Path $Property))
@@ -435,17 +435,17 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
         $actualProperty = $actualProperties | Where-Object { $_.Name -eq $propertyName}
         if (-not $actualProperty)
         {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "Property '$propertyName' was not found on `$Actual."
+            v -Difference "Property '$propertyName' was not found on `$Actual."
             "Expected has property '$PropertyName' that the other object does not have."
             continue
         }
-        C:\Program Files (x86)\vim\vim80\vim.exe "Property '$propertyName` was found on `$Actual, comparing them for equivalence."
+        v "Property '$propertyName` was found on `$Actual, comparing them for equivalence."
         $differences = Compare-Equivalent -Expected $p.Value -Actual $actualProperty.Value -Path "$Property.$propertyName" -Options $Options
         if (-not $differences) {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "Property '$propertyName` is equivalent."
+            v -Equivalence "Property '$propertyName` is equivalent."
         }
         else {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "Property '$propertyName` is not equivalent."
+            v -Difference "Property '$propertyName` is not equivalent."
         }
         $differences
     }
@@ -461,10 +461,10 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
             Test-IncludedPath -PathSelector Property -Options $Options -Path $Property
 
         if ($filteredPropertiesNotInExpected) {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual has ($(@($filteredPropertiesNotInExpected).Count)) properties that `$Expected does not have: $(Format-Nicely @($filteredPropertiesNotInExpected))."
+            v -Difference "`$Actual has ($(@($filteredPropertiesNotInExpected).Count)) properties that `$Expected does not have: $(Format-Nicely @($filteredPropertiesNotInExpected))."
         }
         else {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual has no extra properties that `$Expected does not have."
+            v -Equivalence "`$Actual has no extra properties that `$Expected does not have."
         }
 
         # fix for powershell v2 where foreach goes once over null
@@ -569,7 +569,7 @@ function Compare-Equivalent {
     )
 
     if ($null -ne $Options.ExludedPaths -and $Options.ExcludedPaths -contains $Path) {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Skip "Current path '$Path' is excluded from the comparison."
+        v -Skip "Current path '$Path' is excluded from the comparison."
         return
     }
 
@@ -577,31 +577,31 @@ function Compare-Equivalent {
     #logic in the functions that follow
     if ($null -eq $Expected)
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is `$null, so we are expecting `$null."
+        v "`$Expected is `$null, so we are expecting `$null."
         if ($Expected -ne $Actual)
         {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected), because it has a value of type $(Format-Nicely $Actual.GetType())."
+            v -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected), because it has a value of type $(Format-Nicely $Actual.GetType())."
             return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         }
         # we terminate here, either we passed the test and return nothing, or we did not
         # and the previous statement returned message
-        C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to `$null, because it is `$null."
+        v -Equivalence "`$Actual is equivalent to `$null, because it is `$null."
         return
     }
 
     if ($null -eq $Actual)
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is $(Format-Nicely), but `$Expected has value of type $(Format-Nicely Get-Type $Expected), so they are not equivalent."
+        v -Difference "`$Actual is $(Format-Nicely), but `$Expected has value of type $(Format-Nicely Get-Type $Expected), so they are not equivalent."
         return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Path
     }
 
-    C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected has type $(Get-Type $Expected), `$Actual has type $(Get-Type $Actual), they are both non-null."
+    v "`$Expected has type $(Get-Type $Expected), `$Actual has type $(Get-Type $Actual), they are both non-null."
 
     #test value types, strings, and single item arrays with values in them as values
     #expand the single item array to get to the value in it
     if (Is-Value -Value $Expected)
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a value (value type, string, single value array, or a scriptblock), we will be comparing `$Actual to value types."
+        v "`$Expected is a value (value type, string, single value array, or a scriptblock), we will be comparing `$Actual to value types."
         Compare-ValueEquivalent -Actual $Actual -Expected $Expected -Property $Path -Options $Options
         return
     }
@@ -609,13 +609,13 @@ function Compare-Equivalent {
     #are the same instance
     if (Test-Same -Expected $Expected -Actual $Actual)
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Expected and `$Actual are equivalent because they are the same object (by reference)."
+        v -Equivalence "`$Expected and `$Actual are equivalent because they are the same object (by reference)."
         return
     }
 
     if (Is-Hashtable -Value $Expected)
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a hashtable, we will be comparing `$Actual to hashtables."
+        v "`$Expected is a hashtable, we will be comparing `$Actual to hashtables."
         Compare-HashtableEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
@@ -623,7 +623,7 @@ function Compare-Equivalent {
     # dictionaries? (they are IEnumerable so they must go before collections)
     if (Is-Dictionary -Value $Expected)
     {
-        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a dictionary, we will be comparing `$Actual to dictionaries."
+        v "`$Expected is a dictionary, we will be comparing `$Actual to dictionaries."
         Compare-DictionaryEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
@@ -631,14 +631,14 @@ function Compare-Equivalent {
     #compare DataTable
     if (Is-DataTable -Value $Expected) {
         # todo add verbose output to data table
-        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a datatable, we will be comparing `$Actual to datatables."
+        v "`$Expected is a datatable, we will be comparing `$Actual to datatables."
         Compare-DataTableEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
 
     #compare collection
     if (Is-Collection -Value $Expected) {
-        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a collection, we will be comparing `$Actual to collections."
+        v "`$Expected is a collection, we will be comparing `$Actual to collections."
         Compare-CollectionEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
@@ -646,12 +646,12 @@ function Compare-Equivalent {
     #compare DataRow
     if (Is-DataRow -Value $Expected) {
         # todo add verbose output to data row
-        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a datarow, we will be comparing `$Actual to datarows."
+        v "`$Expected is a datarow, we will be comparing `$Actual to datarows."
         Compare-DataRowEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
 
-    C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is an object of type $(Get-Type $Expected), we will be comparing `$Actual to objects."
+    v "`$Expected is an object of type $(Get-Type $Expected), we will be comparing `$Actual to objects."
     Compare-ObjectEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
 }
 
@@ -674,7 +674,7 @@ function Assert-Equivalent {
         throw [Assertions.AssertionException]$message
     }
 
-    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual and `$Expected are equivalent."
+    v -Equivalence "`$Actual and `$Expected are equivalent."
 }
 
 function Get-EquivalencyOption {
@@ -724,7 +724,7 @@ function Test-IncludedPath {
 
         if ($fullPath | Like-Any $Options.ExcludedPaths)
         {
-            C:\Program Files (x86)\vim\vim80\vim.exe -Skip "Current path $fullPath is excluded from the comparison."
+            v -Skip "Current path $fullPath is excluded from the comparison."
         }
         else
         {
@@ -748,7 +748,7 @@ function Like-Any {
         foreach ($pathFilter in $PathFilters | Where-Object { $_ }) {
             $r = $Path -like $pathFilter
             if ($r) {
-                C:\Program Files (x86)\vim\vim80\vim.exe -Skip "Path '$Path' matches filter '$pathFilter'."
+                v -Skip "Path '$Path' matches filter '$pathFilter'."
                 return $true
             }
         }

--- a/src/Equivalence/Assert-Equivalent.ps1
+++ b/src/Equivalence/Assert-Equivalent.ps1
@@ -58,7 +58,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
 
     if (-not (Is-Collection -Value $Actual))
     {
-        v -Difference "`$Actual is not a collection it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not a collection it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
         $expectedFormatted = Format-Collection -Value $Expected
         $expectedLength = $expected.Length
         $actualFormatted = Format-Nicely -Value $actual
@@ -66,19 +66,19 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
     }
 
     if (-not (Is-CollectionSize -Expected $Expected -Actual $Actual)) {
-        v -Difference "`$Actual does not have the same size ($($Actual.Length)) as `$Expected ($($Expected.Length)) so they are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual does not have the same size ($($Actual.Length)) as `$Expected ($($Expected.Length)) so they are not equivalent."
         return Get-CollectionSizeNotTheSameMessage -Expected $Expected -Actual $Actual -Property $Property
     }
 
     $eEnd = if ($Expected.Length -is [int]) {$Expected.Length} else {$Expected.Count}
     $aEnd = if ($Actual.Length -is [int]) {$Actual.Length} else {$Actual.Count}
-    v "Comparing items in collection, `$Expected has lenght $eEnd, `$Actual has length $aEnd."
+    C:\Program Files (x86)\vim\vim80\vim.exe "Comparing items in collection, `$Expected has lenght $eEnd, `$Actual has length $aEnd."
     $taken = @()
     $notFound = @()
     $anyDifferent = $false
     for ($e=0; $e -lt $eEnd; $e++) {
         # todo: retest strict order
-        v "`nSearching for `$Expected[$e]:"
+        C:\Program Files (x86)\vim\vim80\vim.exe "`nSearching for `$Expected[$e]:"
         $currentExpected = $Expected[$e]
         $found = $false
         if ($StrictOrder) {
@@ -87,28 +87,28 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
             {
                 $taken += $e
                 $found = $true
-                v -Equivalence "`Found `$Expected[$e]."
+                C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`Found `$Expected[$e]."
             }
         }
         else {
             for ($a=0; $a -lt $aEnd; $a++) {
                 # we already took this item as equivalent to an item
                 # in the expected collection, skip it
-                if ($taken -contains $a) { 
-                    v "Skipping `$Actual[$a] because it is already taken."
+                if ($taken -contains $a) {
+                    C:\Program Files (x86)\vim\vim80\vim.exe "Skipping `$Actual[$a] because it is already taken."
                     continue }
                 $currentActual = $Actual[$a]
                 # -not, because $null means no differences, and some strings means there are differences
-                v "Comparing `$Actual[$a] to `$Expected[$e] to see if they are equivalent."
+                C:\Program Files (x86)\vim\vim80\vim.exe "Comparing `$Actual[$a] to `$Expected[$e] to see if they are equivalent."
                 if (-not (Compare-Equivalent -Expected $currentExpected -Actual $currentActual -Path $Property -Options $Options))
                 {
                     # add the index to the list of taken items so we can skip it
-                    # in the search, this way we can compare collections with 
+                    # in the search, this way we can compare collections with
                     # arrays multiple same items
                     $taken += $a
                     $found = $true
-                    v -Equivalence "`Found equivalent item for `$Expected[$e] at `$Actual[$a]."
-                    # we already found the item we 
+                    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`Found equivalent item for `$Expected[$e] at `$Actual[$a]."
+                    # we already found the item we
                     # can move on to the next item in Exected array
                     break
                 }
@@ -116,26 +116,26 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
         }
         if (-not $found)
         {
-            v -Difference "`$Actual does not contain `$Expected[$e]."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual does not contain `$Expected[$e]."
             $anyDifferent = $true
             $notFound += $currentExpected
         }
     }
 
     # do not depend on $notFound collection here
-    # failing to find a single $null, will return 
+    # failing to find a single $null, will return
     # @($null) which evaluates to false, even though
     # there was a single item that we did not find
     if ($anyDifferent) {
-        v -Difference "`$Actual and `$Expected arrays are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual and `$Expected arrays are not equivalent."
         $Expected = Format-Nicely -Value $Expected
         $Actual = Format-Nicely -Value $Actual
-        $notFoundFormatted = Format-Nicely -Value ( $notFound | % { Format-Nicely -Value $_ } )
+        $notFoundFormatted = Format-Nicely -Value ( $notFound | ForEach-Object { Format-Nicely -Value $_ } )
 
         $propertyMessage = if ($Property) {" in property $Property which is"}
         return "Expected collection$propertyMessage '$Expected' to be equivalent to '$Actual' but some values were missing: '$notFoundFormatted'."
     }
-    v -Equivalence "`$Actual and `$Expected arrays are equivalent."
+    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual and `$Expected arrays are equivalent."
 }
 
 function Compare-DataTableEquivalent ($Expected, $Actual, $Property, $Options) {
@@ -183,7 +183,7 @@ function Compare-DataTableEquivalent ($Expected, $Actual, $Property, $Options) {
     }
     $Expected = Format-Nicely -Value $Expected
     $Actual = Format-Nicely -Value $Actual
-    $notFoundFormatted = Format-Nicely -Value ( $notFound | % { Format-Nicely -Value $_ } )
+    $notFoundFormatted = Format-Nicely -Value ( $notFound | ForEach-Object { Format-Nicely -Value $_ } )
 
     if ($notFound) {
         $propertyMessage = if ($Property) {" in property $Property which is"}
@@ -198,37 +198,37 @@ function Compare-ValueEquivalent ($Actual, $Expected, $Property, $Options) {
         throw [ArgumentException]"Expected must be a Value."
     }
 
-    # we don't specify the options in some tests so here we make 
+    # we don't specify the options in some tests so here we make
     # sure that equivalency is used as the default
     # not ideal but better than rewriting 100 tests
-    if (($null -eq $Options) -or 
-        ($null -eq $Options.Comparator) -or 
+    if (($null -eq $Options) -or
+        ($null -eq $Options.Comparator) -or
         ("Equivalency" -eq $Options.Comparator)) {
-        v "Equivalency comparator is used, values will be compared for equivalency."
+        C:\Program Files (x86)\vim\vim80\vim.exe "Equivalency comparator is used, values will be compared for equivalency."
         # fix that string 'false' becomes $true boolean
         if ($Actual -is [Bool] -and $Expected -is [string] -and "$Expected" -eq 'False')
         {
-            v "`$Actual is a boolean, and `$Expected is a 'False' string, which we consider equivalent to boolean `$false. Setting `$Expected to `$false."
+            C:\Program Files (x86)\vim\vim80\vim.exe "`$Actual is a boolean, and `$Expected is a 'False' string, which we consider equivalent to boolean `$false. Setting `$Expected to `$false."
             $Expected = $false
             if ($Expected -ne $Actual)
             {
-                v -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
+                C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
                 return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Property -Options $Options
             }
-            v -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
             return
         }
 
         if ($Expected -is [Bool] -and $Actual -is [string] -and "$Actual" -eq 'False')
         {
-            v "`$Actual is a 'False' string, which we consider equivalent to boolean `$false. `$Expected is a boolean. Setting `$Actual to `$false."
+            C:\Program Files (x86)\vim\vim80\vim.exe "`$Actual is a 'False' string, which we consider equivalent to boolean `$false. `$Expected is a boolean. Setting `$Actual to `$false."
             $Actual = $false
             if ($Expected -ne $Actual)
             {
-                v -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
+                C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
                 return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Property -Options $Options
             }
-            v -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual)."
             return
         }
 
@@ -236,33 +236,33 @@ function Compare-ValueEquivalent ($Actual, $Expected, $Property, $Options) {
         if (Is-ScriptBlock -Value $Expected)
         {
             # todo: compare by equivalency like strings?
-            v "`$Expected is a ScriptBlock, scriptblocks are considered equivalent when their content is equal. Converting `$Expected to string."
+            C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a ScriptBlock, scriptblocks are considered equivalent when their content is equal. Converting `$Expected to string."
             #forcing scriptblock to serialize to string and then comparing that
             if ("$Expected" -ne $Actual)
             {
                 # todo: difference on index?
-                v -Difference "`$Actual is not equivalent to `$Expected because their contents differ."
+                C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to `$Expected because their contents differ."
                 return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Path -Options $Options
             }
-            v -Equivalence "`$Actual is equivalent to `$Expected because their contents are equal."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to `$Expected because their contents are equal."
             return
         }
     }
-    else 
+    else
     {
-        v "Equality comparator is used, values will be compared for equality."
+        C:\Program Files (x86)\vim\vim80\vim.exe "Equality comparator is used, values will be compared for equality."
     }
 
-    v "Comparing values as $(Format-Nicely (Get-Type $Expected)) because `$Expected has that type."
+    C:\Program Files (x86)\vim\vim80\vim.exe "Comparing values as $(Format-Nicely (Get-Type $Expected)) because `$Expected has that type."
     # todo: shorter messages when both sides have the same type (do not compare by using -is, instead query the type and compare it) because -is is true even for parent types
     $type = Get-Type $Expected
     $coalescedActual = $Actual -as $type
     if ($Expected -ne $Actual)
     {
-        v -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual), and $(Format-Nicely $Actual) coalesced to $(Format-Nicely $type) is $(Format-Nicely $coalescedActual)."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual), and $(Format-Nicely $Actual) coalesced to $(Format-Nicely $type) is $(Format-Nicely $coalescedActual)."
         return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Property -Options $Options
     }
-    v -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual), and $(Format-Nicely $Actual) coalesced to $(Format-Nicely $type) is $(Format-Nicely $coalescedActual)."
+    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to $(Format-Nicely $Expected) because it is $(Format-Nicely $Actual), and $(Format-Nicely $Actual) coalesced to $(Format-Nicely $type) is $(Format-Nicely $coalescedActual)."
 }
 
 function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
@@ -273,18 +273,18 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
 
     if (-not (Is-Hashtable -Value $Actual))
     {
-        v -Difference "`$Actual is not a hashtable it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not a hashtable it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected hashtable '$expectedFormatted', but got '$actualFormatted'."
     }
-    
+
     # todo: if either side or both sides are empty hashtable make the verbose output shorter and nicer
 
     $actualKeys = $Actual.Keys
     $expectedKeys = $Expected.Keys
 
-    v "`Comparing all ($($expectedKeys.Count)) keys from `$Expected to keys in `$Actual."
+    C:\Program Files (x86)\vim\vim80\vim.exe "`Comparing all ($($expectedKeys.Count)) keys from `$Expected to keys in `$Actual."
     $result = @()
     foreach ($k in $expectedKeys)
     {
@@ -294,47 +294,47 @@ function Compare-HashtableEquivalent ($Actual, $Expected, $Property, $Options) {
 
         $actualHasKey = $actualKeys -contains $k
         if (-not $actualHasKey)
-        {   
-            v -Difference "`$Actual is missing key '$k'."
+        {
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is missing key '$k'."
             $result += "Expected has key '$k' that the other object does not have."
             continue
         }
 
         $expectedValue = $Expected[$k]
         $actualValue = $Actual[$k]
-        v "Both `$Actual and `$Expected have key '$k', comparing thier contents."
+        C:\Program Files (x86)\vim\vim80\vim.exe "Both `$Actual and `$Expected have key '$k', comparing thier contents."
         $result += Compare-Equivalent -Expected $expectedValue -Actual $actualValue -Path "$Property.$k" -Options $Options
     }
 
     if (!$Options.ExcludePathsNotOnExpected) {
         # fix for powershell 2 where the array needs to be explicit
-        $keysNotInExpected = @( $actualKeys | where { $expectedKeys -notcontains $_ })
+        $keysNotInExpected = @( $actualKeys | Where-Object { $expectedKeys -notcontains $_ })
 
         $filteredKeysNotInExpected = @( $keysNotInExpected | Test-IncludedPath -PathSelector Hashtable -Path $Property -Options $Options)
 
         # fix for powershell v2 where foreach goes once over null
-        if ($filteredKeysNotInExpected | where { $_ }) {
-            v -Difference "`$Actual has $($filteredKeysNotInExpected.Count) keys that were not found on `$Expected: $(Format-Nicely @($filteredKeysNotInExpected))."
+        if ($filteredKeysNotInExpected | Where-Object { $_ }) {
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual has $($filteredKeysNotInExpected.Count) keys that were not found on `$Expected: $(Format-Nicely @($filteredKeysNotInExpected))."
         }
         else {
-            v "`$Actual has no keys that we did not find on `$Expected."
+            C:\Program Files (x86)\vim\vim80\vim.exe "`$Actual has no keys that we did not find on `$Expected."
         }
-        
-        foreach ($k in $filteredKeysNotInExpected | where { $_ })
+
+        foreach ($k in $filteredKeysNotInExpected | Where-Object { $_ })
         {
             $result += "Expected is missing key '$k' that the other object has."
         }
     }
 
-    if ($result | where { $_ })
+    if ($result | Where-Object { $_ })
     {
-        v -Difference "Hashtables `$Actual and `$Expected are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "Hashtables `$Actual and `$Expected are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected hashtable '$expectedFormatted', but got '$actualFormatted'.`n$($result -join "`n")"
     }
 
-    v -Equivalence "Hastables `$Actual and `$Expected are equivalent."
+    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "Hastables `$Actual and `$Expected are equivalent."
 }
 
 function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) {
@@ -345,7 +345,7 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
 
     if (-not (Is-Dictionary -Value $Actual))
     {
-        v -Difference "`$Actual is not a dictionary it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not a dictionary it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected dictionary '$expectedFormatted', but got '$actualFormatted'."
@@ -356,7 +356,7 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
     $actualKeys = $Actual.Keys
     $expectedKeys = $Expected.Keys
 
-    v "`Comparing all ($($expectedKeys.Count)) keys from `$Expected to keys in `$Actual."
+    C:\Program Files (x86)\vim\vim80\vim.exe "`Comparing all ($($expectedKeys.Count)) keys from `$Expected to keys in `$Actual."
     $result = @()
     foreach ($k in $expectedKeys)
     {
@@ -367,30 +367,30 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
         $actualHasKey = $actualKeys -contains $k
         if (-not $actualHasKey)
         {
-            v -Difference "`$Actual is missing key '$k'."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is missing key '$k'."
             $result += "Expected has key '$k' that the other object does not have."
             continue
         }
 
         $expectedValue = $Expected[$k]
         $actualValue = $Actual[$k]
-        v "Both `$Actual and `$Expected have key '$k', comparing thier contents."
+        C:\Program Files (x86)\vim\vim80\vim.exe "Both `$Actual and `$Expected have key '$k', comparing thier contents."
         $result += Compare-Equivalent -Expected $expectedValue -Actual $actualValue -Path "$Property.$k" -Options $Options
     }
     if (!$Options.ExcludePathsNotOnExpected) {
         # fix for powershell 2 where the array needs to be explicit
-        $keysNotInExpected = @( $actualKeys | where { $expectedKeys -notcontains $_ } )
+        $keysNotInExpected = @( $actualKeys | Where-Object { $expectedKeys -notcontains $_ } )
         $filteredKeysNotInExpected = @( $keysNotInExpected | Test-IncludedPath -PathSelector Hashtable -Path $Property -Options $Options )
-        
+
         # fix for powershell v2 where foreach goes once over null
-        if ($filteredKeysNotInExpected | where { $_ }) {
-            v -Difference "`$Actual has $($filteredKeysNotInExpected.Count) keys that were not found on `$Expected: $(Format-Nicely @($filteredKeysNotInExpected))."
+        if ($filteredKeysNotInExpected | Where-Object { $_ }) {
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual has $($filteredKeysNotInExpected.Count) keys that were not found on `$Expected: $(Format-Nicely @($filteredKeysNotInExpected))."
         }
         else {
-            v "`$Actual has no keys that we did not find on `$Expected."
+            C:\Program Files (x86)\vim\vim80\vim.exe "`$Actual has no keys that we did not find on `$Expected."
         }
-        
-        foreach ($k in $filteredKeysNotInExpected | where { $_ })
+
+        foreach ($k in $filteredKeysNotInExpected | Where-Object { $_ })
         {
             $result += "Expected is missing key '$k' that the other object has."
         }
@@ -398,12 +398,12 @@ function Compare-DictionaryEquivalent ($Actual, $Expected, $Property, $Options) 
 
     if ($result)
     {
-        v -Difference "Dictionaries `$Actual and `$Expected are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "Dictionaries `$Actual and `$Expected are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected dictionary '$expectedFormatted', but got '$actualFormatted'.`n$($result -join "`n")"
     }
-    v -Equivalence "Dictionaries `$Actual and `$Expected are equivalent."
+    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "Dictionaries `$Actual and `$Expected are equivalent."
 }
 
 function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
@@ -414,7 +414,7 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
     }
 
     if (-not (Is-Object -Value $Actual)) {
-        v -Difference "`$Actual is not an object it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not an object it is a $(Format-Nicely (Get-Type $Actual)), so they are not equivalent."
         $expectedFormatted = Format-Nicely -Value $Expected
         $actualFormatted = Format-Nicely -Value $Actual
         return "Expected object '$expectedFormatted', but got '$actualFormatted'."
@@ -423,7 +423,7 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
     $actualProperties = $Actual.PsObject.Properties
     $expectedProperties = $Expected.PsObject.Properties
 
-    v "Comparing ($(@($expectedProperties).Count)) properties of `$Expected to `$Actual."
+    C:\Program Files (x86)\vim\vim80\vim.exe "Comparing ($(@($expectedProperties).Count)) properties of `$Expected to `$Actual."
     foreach ($p in $expectedProperties)
     {
         if (-not (Test-IncludedPath -PathSelector Property -InputObject $p -Options $Options -Path $Property))
@@ -432,43 +432,43 @@ function Compare-ObjectEquivalent ($Actual, $Expected, $Property, $Options) {
         }
 
         $propertyName = $p.Name
-        $actualProperty = $actualProperties | Where { $_.Name -eq $propertyName}
+        $actualProperty = $actualProperties | Where-Object { $_.Name -eq $propertyName}
         if (-not $actualProperty)
         {
-            v -Difference "Property '$propertyName' was not found on `$Actual."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "Property '$propertyName' was not found on `$Actual."
             "Expected has property '$PropertyName' that the other object does not have."
             continue
         }
-        v "Property '$propertyName` was found on `$Actual, comparing them for equivalence."
+        C:\Program Files (x86)\vim\vim80\vim.exe "Property '$propertyName` was found on `$Actual, comparing them for equivalence."
         $differences = Compare-Equivalent -Expected $p.Value -Actual $actualProperty.Value -Path "$Property.$propertyName" -Options $Options
         if (-not $differences) {
-            v -Equivalence "Property '$propertyName` is equivalent."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "Property '$propertyName` is equivalent."
         }
         else {
-            v -Difference "Property '$propertyName` is not equivalent."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "Property '$propertyName` is not equivalent."
         }
         $differences
     }
 
     if (!$Options.ExcludePathsNotOnExpected) {
         #check if there are any extra actual object props
-        $expectedPropertyNames = $expectedProperties | select -ExpandProperty Name 
+        $expectedPropertyNames = $expectedProperties | Select-Object -ExpandProperty Name
 
-        $propertiesNotInExpected =  @( $actualProperties | where { $expectedPropertyNames -notcontains $_.name })
+        $propertiesNotInExpected =  @( $actualProperties | Where-Object { $expectedPropertyNames -notcontains $_.name })
 
-        # fix for powershell v2 we need to make the array explicit    
-        $filteredPropertiesNotInExpected = $propertiesNotInExpected | 
+        # fix for powershell v2 we need to make the array explicit
+        $filteredPropertiesNotInExpected = $propertiesNotInExpected |
             Test-IncludedPath -PathSelector Property -Options $Options -Path $Property
 
         if ($filteredPropertiesNotInExpected) {
-            v -Difference "`$Actual has ($(@($filteredPropertiesNotInExpected).Count)) properties that `$Expected does not have: $(Format-Nicely @($filteredPropertiesNotInExpected))."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual has ($(@($filteredPropertiesNotInExpected).Count)) properties that `$Expected does not have: $(Format-Nicely @($filteredPropertiesNotInExpected))."
         }
         else {
-            v -Equivalence "`$Actual has no extra properties that `$Expected does not have."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual has no extra properties that `$Expected does not have."
         }
 
         # fix for powershell v2 where foreach goes once over null
-        foreach ($p in $filteredPropertiesNotInExpected | where { $_ })
+        foreach ($p in $filteredPropertiesNotInExpected | Where-Object { $_ })
         {
             "Expected is missing property '$($p.Name)' that the other object has."
         }
@@ -494,7 +494,7 @@ function Compare-DataRowEquivalent ($Actual, $Expected, $Property, $Options) {
     foreach ($p in $expectedProperties)
     {
         $propertyName = $p.Name
-        $actualProperty = $actualProperties | Where { $_.Name -eq $propertyName}
+        $actualProperty = $actualProperties | Where-Object { $_.Name -eq $propertyName}
         if (-not $actualProperty)
         {
             "Expected has property '$PropertyName' that the other object does not have."
@@ -505,12 +505,12 @@ function Compare-DataRowEquivalent ($Actual, $Expected, $Property, $Options) {
     }
 
     #check if there are any extra actual object props
-    $expectedPropertyNames = $expectedProperties | select -ExpandProperty Name
+    $expectedPropertyNames = $expectedProperties | Select-Object -ExpandProperty Name
 
-    $propertiesNotInExpected =  @($actualProperties | where {$expectedPropertyNames -notcontains $_.name })
+    $propertiesNotInExpected =  @($actualProperties | Where-Object {$expectedPropertyNames -notcontains $_.name })
 
     # fix for powershell v2 where foreach goes once over null
-    foreach ($p in $propertiesNotInExpected | where { $_ })
+    foreach ($p in $propertiesNotInExpected | Where-Object { $_ })
     {
         "Expected is missing property '$($p.Name)' that the other object has."
     }
@@ -524,7 +524,7 @@ function v {
         [Switch] $Equivalence,
         [Switch] $Skip
     )
-    
+
     # we are using implict variable $Path
     # from the parent scope, this is ugly
     # and bad practice, but saves us ton of
@@ -559,9 +559,9 @@ function v {
 function Compare-Equivalent {
     [CmdletBinding()]
     param(
-        $Actual, 
-        $Expected, 
-        $Path, 
+        $Actual,
+        $Expected,
+        $Path,
         $Options = (&{
             Write-Warning "Getting default equivalency options, this should never be seen. If you see this and you are not developing Assert, please file issue at https://github.com/nohwnd/Assert/issues"
             Get-EquivalencyOption
@@ -569,39 +569,39 @@ function Compare-Equivalent {
     )
 
     if ($null -ne $Options.ExludedPaths -and $Options.ExcludedPaths -contains $Path) {
-        v -Skip "Current path '$Path' is excluded from the comparison."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Skip "Current path '$Path' is excluded from the comparison."
         return
     }
-    
+
     #start by null checks to avoid implementing null handling
     #logic in the functions that follow
     if ($null -eq $Expected)
     {
-        v "`$Expected is `$null, so we are expecting `$null."
+        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is `$null, so we are expecting `$null."
         if ($Expected -ne $Actual)
         {
-            v -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected), because it has a value of type $(Format-Nicely $Actual.GetType())."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is not equivalent to $(Format-Nicely $Expected), because it has a value of type $(Format-Nicely $Actual.GetType())."
             return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         }
-        # we terminate here, either we passed the test and return nothing, or we did not 
+        # we terminate here, either we passed the test and return nothing, or we did not
         # and the previous statement returned message
-        v -Equivalence "`$Actual is equivalent to `$null, because it is `$null."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual is equivalent to `$null, because it is `$null."
         return
     }
 
     if ($null -eq $Actual)
     {
-        v -Difference "`$Actual is $(Format-Nicely), but `$Expected has value of type $(Format-Nicely Get-Type $Expected), so they are not equivalent."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Difference "`$Actual is $(Format-Nicely), but `$Expected has value of type $(Format-Nicely Get-Type $Expected), so they are not equivalent."
         return Get-ValueNotEquivalentMessage -Expected $Expected -Actual $Actual -Property $Path
     }
 
-    v "`$Expected has type $(Get-Type $Expected), `$Actual has type $(Get-Type $Actual), they are both non-null."
+    C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected has type $(Get-Type $Expected), `$Actual has type $(Get-Type $Actual), they are both non-null."
 
     #test value types, strings, and single item arrays with values in them as values
     #expand the single item array to get to the value in it
     if (Is-Value -Value $Expected)
     {
-        v "`$Expected is a value (value type, string, single value array, or a scriptblock), we will be comparing `$Actual to value types."
+        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a value (value type, string, single value array, or a scriptblock), we will be comparing `$Actual to value types."
         Compare-ValueEquivalent -Actual $Actual -Expected $Expected -Property $Path -Options $Options
         return
     }
@@ -609,13 +609,13 @@ function Compare-Equivalent {
     #are the same instance
     if (Test-Same -Expected $Expected -Actual $Actual)
     {
-        v -Equivalence "`$Expected and `$Actual are equivalent because they are the same object (by reference)."
+        C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Expected and `$Actual are equivalent because they are the same object (by reference)."
         return
     }
 
     if (Is-Hashtable -Value $Expected)
     {
-        v "`$Expected is a hashtable, we will be comparing `$Actual to hashtables."
+        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a hashtable, we will be comparing `$Actual to hashtables."
         Compare-HashtableEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
@@ -623,7 +623,7 @@ function Compare-Equivalent {
     # dictionaries? (they are IEnumerable so they must go before collections)
     if (Is-Dictionary -Value $Expected)
     {
-        v "`$Expected is a dictionary, we will be comparing `$Actual to dictionaries."
+        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a dictionary, we will be comparing `$Actual to dictionaries."
         Compare-DictionaryEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
@@ -631,14 +631,14 @@ function Compare-Equivalent {
     #compare DataTable
     if (Is-DataTable -Value $Expected) {
         # todo add verbose output to data table
-        v "`$Expected is a datatable, we will be comparing `$Actual to datatables."
+        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a datatable, we will be comparing `$Actual to datatables."
         Compare-DataTableEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
 
     #compare collection
     if (Is-Collection -Value $Expected) {
-        v "`$Expected is a collection, we will be comparing `$Actual to collections."
+        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a collection, we will be comparing `$Actual to collections."
         Compare-CollectionEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
@@ -646,26 +646,26 @@ function Compare-Equivalent {
     #compare DataRow
     if (Is-DataRow -Value $Expected) {
         # todo add verbose output to data row
-        v "`$Expected is a datarow, we will be comparing `$Actual to datarows."
+        C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is a datarow, we will be comparing `$Actual to datarows."
         Compare-DataRowEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
         return
     }
 
-    v "`$Expected is an object of type $(Get-Type $Expected), we will be comparing `$Actual to objects."
+    C:\Program Files (x86)\vim\vim80\vim.exe "`$Expected is an object of type $(Get-Type $Expected), we will be comparing `$Actual to objects."
     Compare-ObjectEquivalent -Expected $Expected -Actual $Actual -Property $Path -Options $Options
 }
 
 function Assert-Equivalent {
     [CmdletBinding()]
     param(
-        $Actual, 
+        $Actual,
         $Expected,
         $Options = (Get-EquivalencyOption),
         [Switch] $StrictOrder
     )
 
     $areDifferent = Compare-Equivalent -Actual $Actual -Expected $Expected -Options $Options | Out-String
-    
+
     if ($areDifferent)
     {
         $optionsFormatted = Format-EquivalencyOptions -Options $Options
@@ -673,14 +673,14 @@ function Assert-Equivalent {
         $message = Get-AssertionMessage -Actual $actual -Expected $Expected -Option $optionsFormatted -Pretty -CustomMessage "Expected and actual are not equivalent!`nExpected:`n<expected>`n`nActual:`n<actual>`n`nSummary:`n$areDifferent`n<options>"
         throw [Assertions.AssertionException]$message
     }
-    
-    v -Equivalence "`$Actual and `$Expected are equivalent."
+
+    C:\Program Files (x86)\vim\vim80\vim.exe -Equivalence "`$Actual and `$Expected are equivalent."
 }
 
 function Get-EquivalencyOption {
     param(
         [string[]] $ExcludePath = @(),
-        [switch] $ExcludePathsNotOnExpected, 
+        [switch] $ExcludePathsNotOnExpected,
         [ValidateSet('Equivalency', 'Equality')]
         [string] $Comparator = 'Equivalency'
     )
@@ -702,7 +702,7 @@ function Test-IncludedPath {
         [Parameter(Mandatory=$true)]
         [ValidateSet("Property", "Hashtable")]
         $PathSelector
-    ) 
+    )
 
     begin {
         $selector = switch ($PathSelector) {
@@ -712,7 +712,7 @@ function Test-IncludedPath {
         }
     }
 
-    process { 
+    process {
         if ($null -eq $Options.ExcludedPaths)
         {
             return $InputObject
@@ -724,17 +724,17 @@ function Test-IncludedPath {
 
         if ($fullPath | Like-Any $Options.ExcludedPaths)
         {
-            v -Skip "Current path $fullPath is excluded from the comparison."
+            C:\Program Files (x86)\vim\vim80\vim.exe -Skip "Current path $fullPath is excluded from the comparison."
         }
-        else 
+        else
         {
             $InputObject
         }
     }
-} 
+}
 
 function Format-EquivalencyOptions ($Options) {
-    $Options.ExcludedPaths | foreach { "Exclude path '$_'" }
+    $Options.ExcludedPaths | ForEach-Object { "Exclude path '$_'" }
     if ($Options.ExcludePathsNotOnExpected) { "Excluding all paths not found on Expected" }
 }
 
@@ -745,10 +745,10 @@ function Like-Any {
         [String] $Path
     )
     process {
-        foreach ($pathFilter in $PathFilters | where { $_ }) {
+        foreach ($pathFilter in $PathFilters | Where-Object { $_ }) {
             $r = $Path -like $pathFilter
-            if ($r) { 
-                v -Skip "Path '$Path' matches filter '$pathFilter'."
+            if ($r) {
+                C:\Program Files (x86)\vim\vim80\vim.exe -Skip "Path '$Path' matches filter '$pathFilter'."
                 return $true
             }
         }

--- a/src/General/Assert-Equal.ps1
+++ b/src/General/Assert-Equal.ps1
@@ -1,16 +1,16 @@
 function Assert-Equal {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    
-    if ((Ensure-ExpectedIsNotCollection $Expected) -ne $Actual) 
-    { 
+
+    if ((Ensure-ExpectedIsNotCollection $Expected) -ne $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <expectedType> '<expected>', but got <actualType> '<actual>'."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/General/Assert-GreaterThan.ps1
+++ b/src/General/Assert-GreaterThan.ps1
@@ -1,15 +1,15 @@
 function Assert-GreaterThan {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ((Ensure-ExpectedIsNotCollection $Expected) -ge $Actual) 
-    { 
+    if ((Ensure-ExpectedIsNotCollection $Expected) -ge $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <actualType> '<actual>' to be greater than <expectedType> '<expected>', but it was not."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/General/Assert-GreaterThanOrEqual.ps1
+++ b/src/General/Assert-GreaterThanOrEqual.ps1
@@ -1,15 +1,15 @@
 function Assert-GreaterThanOrEqual {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ((Ensure-ExpectedIsNotCollection $Expected) -gt $Actual) 
-    { 
+    if ((Ensure-ExpectedIsNotCollection $Expected) -gt $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <actualType> '<actual>' to be greater than or equal to <expectedType> '<expected>', but it was not."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/General/Assert-LessThan.ps1
+++ b/src/General/Assert-LessThan.ps1
@@ -1,15 +1,15 @@
 function Assert-LessThan {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ((Ensure-ExpectedIsNotCollection $Expected) -le $Actual) 
-    { 
+    if ((Ensure-ExpectedIsNotCollection $Expected) -le $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <actualType> '<actual>' to be less than <expectedType> '<expected>', but it was not."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/General/Assert-LessThanOrEqual.ps1
+++ b/src/General/Assert-LessThanOrEqual.ps1
@@ -1,15 +1,15 @@
 function Assert-LessThanOrEqual {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ((Ensure-ExpectedIsNotCollection $Expected) -lt $Actual) 
-    { 
+    if ((Ensure-ExpectedIsNotCollection $Expected) -lt $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <actualType> '<actual>' to be less than or equal to <expectedType> '<expected>', but it was not."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/General/Assert-NotEqual.ps1
+++ b/src/General/Assert-NotEqual.ps1
@@ -1,15 +1,15 @@
 function Assert-NotEqual {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ((Ensure-ExpectedIsNotCollection $Expected) -eq $Actual) 
-    { 
+    if ((Ensure-ExpectedIsNotCollection $Expected) -eq $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <expectedType> '<expected>', to be different than the actual value, but they were the same."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/General/Assert-NotNull.ps1
+++ b/src/General/Assert-NotNull.ps1
@@ -1,13 +1,13 @@
 function Assert-NotNull {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ($null -eq $Actual) 
-    { 
+    if ($null -eq $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected not `$null, but got `$null."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/General/Assert-NotSame.ps1
+++ b/src/General/Assert-NotSame.ps1
@@ -1,7 +1,7 @@
 function Assert-NotSame {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
@@ -9,10 +9,10 @@ function Assert-NotSame {
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
     if ([object]::ReferenceEquals($Expected, $Actual))
-    { 
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <expectedType> '<expected>', to not be the same instance."
         throw [Assertions.AssertionException]$Message
     }
-    
+
     $Actual
 }

--- a/src/General/Assert-NotType.ps1
+++ b/src/General/Assert-NotType.ps1
@@ -1,15 +1,15 @@
 function Assert-NotType {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         [Type]$Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ($Actual -is $Expected) 
-    { 
+    if ($Actual -is $Expected)
+    {
         $type = [string]$Expected
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected value to be of different type than '$type', but got '<actual>' of type '<actualType>'."
         throw [Assertions.AssertionException]$Message

--- a/src/General/Assert-Null.ps1
+++ b/src/General/Assert-Null.ps1
@@ -1,13 +1,13 @@
 function Assert-Null {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ($null -ne $Actual) 
-    { 
+    if ($null -ne $Actual)
+    {
         $Message = Get-AssertionMessage -Expected $null -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected `$null, but got <actualType> '<actual>'."
         throw [Assertions.AssertionException]$Message
     }

--- a/src/General/Assert-Same.ps1
+++ b/src/General/Assert-Same.ps1
@@ -1,7 +1,7 @@
 function Assert-Same {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         $Expected,
         [String]$CustomMessage
@@ -13,11 +13,11 @@ function Assert-Same {
     }
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if (-not ([object]::ReferenceEquals($Expected, $Actual))) 
-    { 
+    if (-not ([object]::ReferenceEquals($Expected, $Actual)))
+    {
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected <expectedType> '<expected>', to be the same instance but it was not."
         throw [Assertions.AssertionException]$Message
     }
-    
+
     $Actual
 }

--- a/src/General/Assert-Type.ps1
+++ b/src/General/Assert-Type.ps1
@@ -1,15 +1,15 @@
 function Assert-Type {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         [Type]$Expected,
         [String]$CustomMessage
     )
 
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
-    if ($Actual -isnot $Expected) 
-    { 
+    if ($Actual -isnot $Expected)
+    {
         $type = [string]$Expected
         $Message = Get-AssertionMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -DefaultMessage "Expected value to be of type '$type', but got '<actual>' of type '<actualType>'."
         throw [Assertions.AssertionException]$Message

--- a/src/String/Assert-Like.ps1
+++ b/src/String/Assert-Like.ps1
@@ -1,22 +1,22 @@
 function Test-Like
 {
     param (
-        [String]$Expected, 
-        $Actual, 
+        [String]$Expected,
+        $Actual,
         [switch]$CaseSensitive
     )
 
-    if (-not $CaseSensitive) 
+    if (-not $CaseSensitive)
     {
         $Actual -like $Expected
-    } 
-    else 
+    }
+    else
     {
         $Actual -clike $Expected
     }
 }
 
-function Get-LikeDefaultFailureMessage ([String]$Expected, $Actual, [switch]$CaseSensitive) 
+function Get-LikeDefaultFailureMessage ([String]$Expected, $Actual, [switch]$CaseSensitive)
 {
     $caseSensitiveMessage = ""
     if ($CaseSensitive)
@@ -30,28 +30,28 @@ function Assert-Like
 {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0, Mandatory=$true)]
         [String]$Expected,
         [Switch]$CaseSensitive,
         [String]$CustomMessage
     )
-    
+
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
 
     if ($Actual -isnot [string])
     {
         throw [ArgumentException]"Actual is expected to be string, to avoid confusing behavior that -like operator exhibits with collections. To assert on collections use Assert-Any, Assert-All or some other collection assertion."
     }
-    
+
     $stringsAreAlike = Test-Like -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace
-    if (-not ($stringsAreAlike)) 
+    if (-not ($stringsAreAlike))
     {
         if (-not $CustomMessage)
         {
             $formattedMessage = Get-LikeDefaultFailureMessage -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive
         }
-        else 
+        else
         {
             $formattedMessage = Get-CustomFailureMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -CaseSensitive:$CaseSensitive
         }

--- a/src/String/Assert-NotLike.ps1
+++ b/src/String/Assert-NotLike.ps1
@@ -1,22 +1,22 @@
 function Test-NotLike
 {
     param (
-        [String]$Expected, 
-        $Actual, 
+        [String]$Expected,
+        $Actual,
         [switch]$CaseSensitive
     )
 
-    if (-not $CaseSensitive) 
+    if (-not $CaseSensitive)
     {
         $Actual -NotLike $Expected
-    } 
-    else 
+    }
+    else
     {
         $actual -cNotLike $Expected
     }
 }
 
-function Get-NotLikeDefaultFailureMessage ([String]$Expected, $Actual, [switch]$CaseSensitive) 
+function Get-NotLikeDefaultFailureMessage ([String]$Expected, $Actual, [switch]$CaseSensitive)
 {
     $caseSensitiveMessage = ""
     if ($CaseSensitive)
@@ -30,13 +30,13 @@ function Assert-NotLike
 {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0, Mandatory=$true)]
         [String]$Expected,
         [Switch]$CaseSensitive,
         [String]$CustomMessage
     )
-    
+
     $Actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
 
     if ($Actual -isnot [string])
@@ -45,13 +45,13 @@ function Assert-NotLike
     }
 
     $stringsAreANotLike = Test-NotLike -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace
-    if (-not ($stringsAreANotLike)) 
+    if (-not ($stringsAreANotLike))
     {
         if (-not $CustomMessage)
         {
             $formattedMessage = Get-NotLikeDefaultFailureMessage -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive
         }
-        else 
+        else
         {
             $formattedMessage = Get-CustomFailureMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage -CaseSensitive:$CaseSensitive
         }

--- a/src/String/Assert-StringEqual.ps1
+++ b/src/String/Assert-StringEqual.ps1
@@ -1,58 +1,58 @@
-function Test-StringEqual 
+function Test-StringEqual
 {
     param (
-        [String]$Expected, 
-        $Actual, 
+        [String]$Expected,
+        $Actual,
         [switch]$CaseSensitive,
         [switch]$IgnoreWhitespace
     )
 
     if ($IgnoreWhitespace)
-    { 
+    {
         $Expected = $Expected -replace '\s'
         $Actual = $Actual -replace '\s'
     }
 
-    if (-not $CaseSensitive) 
+    if (-not $CaseSensitive)
     {
         $Expected -eq $Actual
-    } 
-    else 
+    }
+    else
     {
         $Expected -ceq $Actual
     }
 }
 
-function Get-StringEqualDefaultFailureMessage ([String]$Expected, $Actual) 
+function Get-StringEqualDefaultFailureMessage ([String]$Expected, $Actual)
 {
     "Expected the string to be '$Expected' but got '$Actual'."
 }
 
-function Assert-StringEqual 
+function Assert-StringEqual
 {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         [String]$Expected,
         [String]$CustomMessage,
         [switch]$CaseSensitive,
         [switch]$IgnoreWhitespace
     )
-    
+
     $_actual = Collect-Input -ParameterInput $Actual -PipelineInput $local:Input
 
     if (-not $CustomMessage)
     {
         $formattedMessage = Get-StringEqualDefaultFailureMessage -Expected $Expected -Actual $_actual
     }
-    else 
+    else
     {
         $formattedMessage = Get-CustomFailureMessage -Expected $Expected -Actual $_actual -CustomMessage $CustomMessage
     }
 
     $stringsAreEqual = Test-StringEqual -Expected $Expected -Actual $_actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace
-    if (-not ($stringsAreEqual)) 
+    if (-not ($stringsAreEqual))
     {
         throw [Assertions.AssertionException]$formattedMessage
     }

--- a/src/String/Assert-StringNotEqual.ps1
+++ b/src/String/Assert-StringNotEqual.ps1
@@ -1,13 +1,13 @@
-function Get-StringNotEqualDefaultFailureMessage ([String]$Expected, $Actual) 
+function Get-StringNotEqualDefaultFailureMessage ([String]$Expected, $Actual)
 {
     "Expected the strings to be different but they were the same '$Expected'."
 }
 
-function Assert-StringNotEqual 
+function Assert-StringNotEqual
 {
     param (
         [Parameter(Position=1, ValueFromPipeline=$true)]
-        $Actual, 
+        $Actual,
         [Parameter(Position=0)]
         [String]$Expected,
         [String]$CustomMessage,
@@ -15,13 +15,13 @@ function Assert-StringNotEqual
         [switch]$IgnoreWhitespace
     )
 
-    if (Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace) 
+    if (Test-StringEqual -Expected $Expected -Actual $Actual -CaseSensitive:$CaseSensitive -IgnoreWhitespace:$IgnoreWhiteSpace)
     {
         if (-not $CustomMessage)
         {
             $formattedMessage = Get-StringNotEqualDefaultFailureMessage -Expected $Expected -Actual $Actual
         }
-        else 
+        else
         {
             $formattedMessage = Get-CustomFailureMessage -Expected $Expected -Actual $Actual -CustomMessage $CustomMessage
         }

--- a/tst/Boolean/Assert-False.Tests.ps1
+++ b/tst/Boolean/Assert-False.Tests.ps1
@@ -26,7 +26,7 @@ Describe "Assert-False" {
         It "Given value '<actual>' that is not `$false it returns expected message '<message>'" -TestCases @(
             @{ Actual = $true ; Message = "Expected bool '`$true' to be bool '`$false' or falsy value 0, """", `$null, @()."},
             @{ Actual = 10 ; Message = "Expected int '10' to be bool '`$false' or falsy value 0, """", `$null, @()."}
-        ) { 
+        ) {
             param($Actual, $Message)
             $error = { Assert-False -Actual $Actual } | Verify-AssertionFailed
             $error.Exception.Message | Verify-Equal $Message

--- a/tst/Boolean/Assert-True.Tests.ps1
+++ b/tst/Boolean/Assert-True.Tests.ps1
@@ -22,7 +22,7 @@ Describe "Assert-True" {
         It "Given value '<expected>' that is not `$true it returns expected message '<message>'" -TestCases @(
             @{ Actual = $false ; Message = "Expected bool '`$false' to be bool '`$true' or truthy value."},
             @{ Actual = 0 ; Message = "Expected int '0' to be bool '`$true' or truthy value."}
-        ) { 
+        ) {
             param($Actual, $Message)
             $error = { Assert-True -Actual $Actual } | Verify-AssertionFailed
             $error.Exception.Message | Verify-Equal $Message

--- a/tst/Collection/Assert-All.Tests.ps1
+++ b/tst/Collection/Assert-All.Tests.ps1
@@ -27,7 +27,7 @@ Describe "Assert-All" {
 
     It "Returns the value on output" {
         $expected = "a","b"
-        $v = $expected | Assert-All { $true } 
+        $v = $expected | Assert-All { $true }
         $v[0] | Verify-Equal $expected[0]
         $v[1] | Verify-Equal $expected[1]
     }

--- a/tst/Collection/Assert-Any.Tests.ps1
+++ b/tst/Collection/Assert-Any.Tests.ps1
@@ -29,7 +29,7 @@ Describe "Assert-Any" {
 
     It "Returns the value on output" {
         $expected = "a","b"
-        $v = $expected | Assert-Any { $true } 
+        $v = $expected | Assert-Any { $true }
         $v[0] | Verify-Equal $expected[0]
         $v[1] | Verify-Equal $expected[1]
     }

--- a/tst/Collection/Assert-Contain.Tests.ps1
+++ b/tst/Collection/Assert-Contain.Tests.ps1
@@ -5,7 +5,7 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Fails when collection of single item does not contain the expected item" {
-            $error = { @(5) | Assert-Contain 1 } | Verify-AssertionFailed 
+            $error = { @(5) | Assert-Contain 1 } | Verify-AssertionFailed
             $error.Exception.Message | Verify-Equal "Expected int '1' to be present in collection '5', but it was not there."
         }
 

--- a/tst/Common/Ensure-ExpectedIsNotCollection.Tests.ps1
+++ b/tst/Common/Ensure-ExpectedIsNotCollection.Tests.ps1
@@ -1,17 +1,17 @@
-InModuleScope -ModuleName Assert { 
+InModuleScope -ModuleName Assert {
     Describe "Ensure-ExpectedIsNotCollection" {
-        It "Given a collection it throws ArgumentException" { 
+        It "Given a collection it throws ArgumentException" {
             $error = { Ensure-ExpectedIsNotCollection -InputObject @() } | Verify-Throw
             $error.Exception | Verify-Type ([ArgumentException])
         }
 
-        It "Given a collection it throws correct message" { 
+        It "Given a collection it throws correct message" {
             $error = { Ensure-ExpectedIsNotCollection -InputObject @() } | Verify-Throw
             $error.Exception.Message | Verify-Equal 'You provided a collection to the -Expected parameter. Using a collection on the -Expected side is not allowed by this assertion, because it leads to unexpected behavior. Please use Assert-Any, Assert-All or some other specialized collection assertion.'
         }
 
 
-        It "Given a value it passes it to output when it is not a collection" { 
+        It "Given a value it passes it to output when it is not a collection" {
             Ensure-ExpectedIsNotCollection -InputObject 'a' | Verify-Equal 'a'
         }
     }

--- a/tst/Common/Get-AssertionMessage.Tests.ps1
+++ b/tst/Common/Get-AssertionMessage.Tests.ps1
@@ -36,11 +36,11 @@ InModuleScope -ModuleName Assert {
             Get-AssertionMessage -CustomMessage $customMessage -Expected 'a' -Actual 'b' -Option "CaseSensitive","IgnoreWhitespace" | Verify-Equal $expected
         }
 
-        It "returns correct message when additional data are provided" { 
+        It "returns correct message when additional data are provided" {
             $expected = "but 3 of them '1, 2, 3' did not pass the filter."
 
             $customMessage = "but <actualFilteredCount> of them '<actualFiltered>' did not pass the filter."
-            $data = @{ 
+            $data = @{
                 actualFilteredCount = 3
                 actualFiltered = 1, 2, 3
             }

--- a/tst/Equivalence/Assert-Equivalent.Options.Tests.ps1
+++ b/tst/Equivalence/Assert-Equivalent.Options.Tests.ps1
@@ -6,7 +6,7 @@ InModuleScope -ModuleName Assert {
                 @{ Path = $null }
                 @{ Path = "ParentProperty1" }
                 @{ Path = "ParentProperty1.ParentProperty2" }
-            ) { 
+            ) {
                 param ($Path)
 
             $expected = New-PSObject @{
@@ -26,7 +26,7 @@ InModuleScope -ModuleName Assert {
             @{ Path = $null }
             @{ Path = "ParentProperty1" }
             @{ Path = "ParentProperty1.ParentProperty2" }
-        ) { 
+        ) {
             param ($Path)
             $expected = New-PSObject @{
                 Name = "Jakub"
@@ -40,7 +40,7 @@ InModuleScope -ModuleName Assert {
                 $options = Get-EquivalencyOption -ExcludePath ("$Path.Age".Trim('.'))
                 Compare-Equivalent -Actual $actual -Expected $expected -Path $Path -Options $options | Verify-Null
             }
-        
+
 
         It "Given a full path to a property on object that is in collection it ignores it on the Expected object" {
             $expected = New-PSObject @{
@@ -66,7 +66,7 @@ InModuleScope -ModuleName Assert {
                 )
             }
 
-                
+
                 $options = Get-EquivalencyOption -ExcludePath "ProgrammingLanguages.Type"
                 Compare-Equivalent -Actual $actual -Expected $expected -Options $options | Verify-Null
             }
@@ -95,7 +95,7 @@ InModuleScope -ModuleName Assert {
                 )
             }
 
-                
+
                 $options = Get-EquivalencyOption -ExcludePath "ProgrammingLanguages.Type"
                 Compare-Equivalent -Actual $actual -Expected $expected -Options $options | Verify-Null
             }
@@ -133,7 +133,7 @@ InModuleScope -ModuleName Assert {
             # collections are handled, and we filter out based on the path on the start of Compare-Equivalent
             # so the same rules should apply transitively no matter the collection type
 
-            
+
             It "Given a full path to a key on a hashtable it ignores it on the Expected hashtable" {
                 $expected = @{
                     Name = "C#"
@@ -190,7 +190,7 @@ InModuleScope -ModuleName Assert {
                 Compare-Equivalent -Actual $actual -Expected $expected -Options $options | Verify-Null
             }
 
-        It "Given options it passes them correctly from Assert-Equivalent" { 
+        It "Given options it passes them correctly from Assert-Equivalent" {
             $expected = New-PSObject @{
                 Name = "Jakub"
                 Location = "Prague"
@@ -210,108 +210,108 @@ InModuleScope -ModuleName Assert {
         }
 
         Context "Wildcard path exclusions" {
-            It "Given wildcarded path it ignores it on the expected object" { 
+            It "Given wildcarded path it ignores it on the expected object" {
                 $expected = [PSCustomObject] @{
                     Name = "Jakub"
                     Location = "Prague"
                 }
-    
+
                 $actual = [PSCustomObject] @{
                     Name = "Jakub"
                 }
-    
+
                 $options = Get-EquivalencyOption -ExcludePath Loc*
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
 
-            It "Given wildcarded path it ignores it on the actual object" { 
+            It "Given wildcarded path it ignores it on the actual object" {
                 $expected = [PSCustomObject] @{
                     Name = "Jakub"
                 }
-    
+
                 $actual = [PSCustomObject] @{
                     Name = "Jakub"
                     Location = "Prague"
                 }
-    
+
                 $options = Get-EquivalencyOption -ExcludePath Loc*
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
 
-            It "Given wildcarded path it ignores it on the expected hashtable" { 
+            It "Given wildcarded path it ignores it on the expected hashtable" {
                 $expected = @{
                     Name = "Jakub"
                     Location = "Prague"
                 }
-    
+
                 $actual = @{
                     Name = "Jakub"
                 }
-    
+
                 $options = Get-EquivalencyOption -ExcludePath Loc*
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
 
-            It "Given wildcarded path it ignores it on the actual hashtable" { 
+            It "Given wildcarded path it ignores it on the actual hashtable" {
                 $expected = @{
                     Name = "Jakub"
                 }
-    
+
                 $actual = @{
                     Name = "Jakub"
                     Location = "Prague"
                 }
-    
+
                 $options = Get-EquivalencyOption -ExcludePath Loc*
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
 
-            It "Given wildcarded path it ignores it on the expected dictionary" { 
+            It "Given wildcarded path it ignores it on the expected dictionary" {
                 $expected = New-Dictionary @{
                     Name = "Jakub"
                     Location = "Prague"
                 }
-    
+
                 $actual = New-Dictionary @{
                     Name = "Jakub"
                 }
-    
+
                 $options = Get-EquivalencyOption -ExcludePath Loc*
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
 
-            It "Given wildcarded path it ignores it on the actual dictionary" { 
+            It "Given wildcarded path it ignores it on the actual dictionary" {
                 $expected = New-Dictionary @{
                     Name = "Jakub"
                 }
-    
+
                 $actual = New-Dictionary @{
                     Name = "Jakub"
                     Location = "Prague"
                 }
-    
+
                 $options = Get-EquivalencyOption -ExcludePath Loc*
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
         }
 
         Context "-ExcludePathsNotOnExpected" {
-            It "Given actual object that has more properties that expected it skips them" { 
+            It "Given actual object that has more properties that expected it skips them" {
                 $expected = [PSCustomObject] @{
                     Name = "Jakub"
                 }
-    
+
                 $actual = [PSCustomObject] @{
                     Name = "Jakub"
                     Location = "Prague"
                     Age = 30
                 }
-    
+
                 $options = Get-EquivalencyOption -ExcludePathsNotOnExpected
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
 
-            It "Given actual hashtable that has more keys that expected it skips them" { 
+            It "Given actual hashtable that has more keys that expected it skips them" {
                 $expected = @{
                     Name = "Jakub"
                 }
@@ -323,10 +323,10 @@ InModuleScope -ModuleName Assert {
                 }
 
                 $options = Get-EquivalencyOption -ExcludePathsNotOnExpected
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
 
-            It "Given actual dictionary that has more keys that expected it skips them" { 
+            It "Given actual dictionary that has more keys that expected it skips them" {
                 $expected = New-Dictionary @{
                     Name = "Jakub"
                 }
@@ -338,13 +338,13 @@ InModuleScope -ModuleName Assert {
                 }
 
                 $options = Get-EquivalencyOption -ExcludePathsNotOnExpected
-                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options 
+                Assert-Equivalent -Actual $actual -Expected $expected -Options $Options
             }
         }
     }
 
-    Describe "Compare-Equiavlent - equality comparison options" { 
-        It "Given objects that are equivalent and -Comparator Equality option it compares them as different" { 
+    Describe "Compare-Equiavlent - equality comparison options" {
+        It "Given objects that are equivalent and -Comparator Equality option it compares them as different" {
             $expected = New-PsObject @{
                 LikesIfsInMocks = $false
             }
@@ -361,7 +361,7 @@ InModuleScope -ModuleName Assert {
 
     Describe "Printing Options into difference report" {
 
-        It "Given options that exclude property it shows up in the difference report correctly" { 
+        It "Given options that exclude property it shows up in the difference report correctly" {
                 $options = Get-EquivalencyOption -ExcludePath "Age", "Name", "Person.Age", "Person.Created*"
                 Clear-WhiteSpace (Format-EquivalencyOptions -Options $options) | Verify-Equal (Clear-WhiteSpace "
                     Exclude path 'Age'
@@ -370,7 +370,7 @@ InModuleScope -ModuleName Assert {
                     Exclude path 'Person.Created*'")
         }
 
-        It "Given options that exclude property it shows up in the difference report correctly" { 
+        It "Given options that exclude property it shows up in the difference report correctly" {
             $options = Get-EquivalencyOption -ExcludePathsNotOnExpected
             Clear-WhiteSpace (Format-EquivalencyOptions -Options $options) | Verify-Equal (Clear-WhiteSpace "
             Excluding all paths not found on Expected")

--- a/tst/Equivalence/Assert-Equivalent.Tests.ps1
+++ b/tst/Equivalence/Assert-Equivalent.Tests.ps1
@@ -1,9 +1,9 @@
-Add-Type -TypeDefinition 'namespace Assertions.TestType { 
-    public class Person2 { 
+Add-Type -TypeDefinition 'namespace Assertions.TestType {
+    public class Person2 {
         // powershell v2 mandates fully implemented properties
         string _name;
         int _age;
-        public string Name { get { return _name; } set { _name = value; } } 
+        public string Name { get { return _name; } set { _name = value; } }
         public int Age { get { return _age; } set { _age = value; } }
     }
 }'
@@ -204,7 +204,7 @@ InModuleScope -ModuleName Assert {
             @{ Actual = (1, 1, 1, 1); Expected = (1, 1, 1, 1) }
             @{ Actual = (1, 2, 2, 1); Expected = (2, 1, 2, 1) }
             ##
-            
+
         ) {
             param ($Actual, $Expected)
             Compare-CollectionEquivalent -Actual $Actual -Expected $Expected | Verify-Null
@@ -442,22 +442,22 @@ InModuleScope -ModuleName Assert {
             function SerializeDeserialize ($InputObject) {
                 # psv2 compatibility
                 # $ExpectedDeserialized = [System.Management.Automation.PSSerializer]::Deserialize([System.Management.Automation.PSSerializer]::Serialize($Expected))
-                # Alternatively this could be done in memory via https://github.com/Jaykul/Reflection/blob/master/CliXml.psm1, but I don't want to fiddle with more 
+                # Alternatively this could be done in memory via https://github.com/Jaykul/Reflection/blob/master/CliXml.psm1, but I don't want to fiddle with more
                 # relfection right now
                 try {
                     $path = [IO.Path]::GetTempFileName()
-                
-                    Export-Clixml -Path $path -InputObject $InputObject -Force | Out-Null 
-                    Import-Clixml -Path $path 
+
+                    Export-Clixml -Path $path -InputObject $InputObject -Force | Out-Null
+                    Import-Clixml -Path $path
                 }
                 finally {
                     if ($null -ne $path -and (Test-Path $path)) {
                         Remove-Item -Path $path -Force
                     }
                 }
-            } 
-           
-            
+            }
+
+
             $ExpectedDeserialized = SerializeDeserialize $Expected
             $ActualDeserialized = SerializeDeserialize $Actual
             Assert-Equivalent -Actual $ActualDeserialized -Expected $ExpectedDeserialized

--- a/tst/Exception/Assert-Throw.Tests.ps1
+++ b/tst/Exception/Assert-Throw.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Assert-Throw" {
     }
 
     It "Passes when non-terminating exception is thrown" {
-        
+
         { Write-Error "fail!" } | Assert-Throw
     }
 
@@ -112,7 +112,7 @@ Describe "Assert-Throw" {
         It 'Exception is thrown by throw keyword' {
             { throw "fail!" } | Assert-Throw
         }
-        
+
         It 'Exception is thrown by static .net method' {
             { [io.directory]::delete("non-existing") } | Assert-Throw
         }
@@ -126,7 +126,7 @@ Describe "Assert-Throw" {
         It 'Exception is thrown by division by zero' {
             { 1/$null } | Assert-Throw
         }
-        
+
         It 'Terminating error is thrown by cmdlet failing to bind paramaters' {
             { Get-Item "non-existing" } | Assert-Throw
         }
@@ -150,59 +150,59 @@ Describe "Assert-Throw" {
 
 Describe "General try catch behavior" {
     It 'Gets error record when exception is thrown by throw keyword' {
-        try 
+        try
         {
             &{ throw "fail!" }
         }
-        catch 
+        catch
         {
             $err = $_
         }
-        
+
         $err | Verify-NotNull
         $err | Verify-Type ([Management.Automation.ErrorRecord])
     }
-    
+
     It 'Gets error record when exception is thrown from .net' {
-        try 
+        try
         {
             &{ [io.directory]::delete("non-existing"); }
         }
-        catch 
+        catch
         {
             $err = $_
         }
-        
+
         $err | Verify-NotNull
         $err | Verify-Type ([Management.Automation.ErrorRecord])
     }
 
     It 'Gets error record when non-terminating error is translated to terminating error' {
-        try 
+        try
         {
             &{ Get-Item "non-existing" -ErrorAction 'stop' }
         }
-        catch 
+        catch
         {
             $err = $_
         }
-        
+
         $err | Verify-NotNull
         $err | Verify-Type ([Management.Automation.ErrorRecord])
     }
 
-    
+
     It 'Gets error record when non-terminating error is translated to terminating error' {
-        try 
+        try
         {
             $ErrorActionPreference = 'stop'
             &{ Get-Item "non-existing" }
         }
-        catch 
+        catch
         {
             $err = $_
         }
-        
+
         $err | Verify-NotNull
         $err | Verify-Type ([Management.Automation.ErrorRecord])
     }
@@ -212,18 +212,18 @@ InModuleScope -ModuleName "Assert" {
     Describe "Get-Error" {
         It 'Unwraps error from invoke with context' {
             $ErrorActionPreference = 'stop'
-            try 
+            try
             {
                 $sb = {
                     Get-Item "/non-existing"
                 }
                 Invoke-WithContext $sb -Variables @{ ErrorActionPreference = "Stop" }
             }
-            catch 
+            catch
             {
                 $e = $_
             }
-            
+
             $err = Get-Error $e
             $err.ExceptionMessage | Verify-Like "Cannot find path*because it does not exist."
             $err.ExceptionType | Verify-Equal ([Management.Automation.ItemNotFoundException])

--- a/tst/General/Assert-Equal.Tests.ps1
+++ b/tst/General/Assert-Equal.Tests.ps1
@@ -67,7 +67,7 @@ InModuleScope -ModuleName Assert {
                 @{ Expected = "a" ; Actual = 10 ; Message = "Expected string 'a', but got int '10'."},
                 @{ Expected = "a" ; Actual = 10.1 ; Message = "Expected string 'a', but got double '10.1'."},
                 @{ Expected = "a" ; Actual = 10.1D ; Message = "Expected string 'a', but got decimal '10.1'."}
-            ) { 
+            ) {
                 param($Expected, $Actual, $Message)
                 $error = { Assert-Equal -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
                 $error.Exception.Message | Verify-Equal $Message
@@ -84,7 +84,7 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Given collection to Expected it throws" {
-            $error = { "dummy" | Assert-Equal @() } | Verify-Throw 
+            $error = { "dummy" | Assert-Equal @() } | Verify-Throw
             $error.Exception | Verify-Type ([ArgumentException])
         }
     }

--- a/tst/General/Assert-GreaterThan.Tests.ps1
+++ b/tst/General/Assert-GreaterThan.Tests.ps1
@@ -71,7 +71,7 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Fails for array input even if the last item is greater than then expected value" {
-             $err = {  1,2,3,4 | Assert-GreaterThan 3 } | Verify-Throw 
+             $err = {  1,2,3,4 | Assert-GreaterThan 3 } | Verify-Throw
              $err.Exception | Verify-Type ([System.Management.Automation.RuntimeException])
         }
 
@@ -85,7 +85,7 @@ InModuleScope -ModuleName Assert {
                 @{ Expected = "z" ; Actual = "a" ; Message = "Expected string 'a' to be greater than string 'z', but it was not."},
                 @{ Expected = 10.1 ; Actual = 1.1 ; Message = "Expected double '1.1' to be greater than double '10.1', but it was not."},
                 @{ Expected = 10.1D ; Actual = 1.1D ; Message = "Expected decimal '1.1' to be greater than decimal '10.1', but it was not."}
-            ) { 
+            ) {
                 param($Expected, $Actual, $Message)
                 $error = { Assert-GreaterThan -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
                 $error.Exception.Message | Verify-Equal $Message
@@ -102,7 +102,7 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Given collection to Expected it throws" {
-            $error = { "dummy" | Assert-GreaterThan @() } | Verify-Throw 
+            $error = { "dummy" | Assert-GreaterThan @() } | Verify-Throw
             $error.Exception | Verify-Type ([ArgumentException])
         }
     }

--- a/tst/General/Assert-GreaterThanOrEqual.Tests.ps1
+++ b/tst/General/Assert-GreaterThanOrEqual.Tests.ps1
@@ -71,7 +71,7 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Fails for array input even if the last item is greater than then expected value" {
-             $err = {  1,2,3,4 | Assert-GreaterThanOrEqual 3 } | Verify-Throw 
+             $err = {  1,2,3,4 | Assert-GreaterThanOrEqual 3 } | Verify-Throw
              $err.Exception | Verify-Type ([System.Management.Automation.RuntimeException])
         }
 
@@ -85,7 +85,7 @@ InModuleScope -ModuleName Assert {
                 @{ Expected = "z" ; Actual = "a" ; Message = "Expected string 'a' to be greater than or equal to string 'z', but it was not."},
                 @{ Expected = 10.1 ; Actual = 1.1 ; Message = "Expected double '1.1' to be greater than or equal to double '10.1', but it was not."},
                 @{ Expected = 10.1D ; Actual = 1.1D ; Message = "Expected decimal '1.1' to be greater than or equal to decimal '10.1', but it was not."}
-            ) { 
+            ) {
                 param($Expected, $Actual, $Message)
                 $error = { Assert-GreaterThanOrEqual -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
                 $error.Exception.Message | Verify-Equal $Message
@@ -102,7 +102,7 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Given collection to Expected it throws" {
-            $error = { "dummy" | Assert-GreaterThanOrEqual @() } | Verify-Throw 
+            $error = { "dummy" | Assert-GreaterThanOrEqual @() } | Verify-Throw
             $error.Exception | Verify-Type ([ArgumentException])
         }
     }

--- a/tst/General/Assert-LessThan.Tests.ps1
+++ b/tst/General/Assert-LessThan.Tests.ps1
@@ -70,7 +70,7 @@ Describe "Assert-LessThan" {
     }
 
     It "Fails for array input even if the last item is less than the expected value" {
-            $err = {  4,3,2,1 | Assert-LessThan 3 } | Verify-Throw 
+            $err = {  4,3,2,1 | Assert-LessThan 3 } | Verify-Throw
             $err.Exception | Verify-Type ([System.Management.Automation.RuntimeException])
     }
 
@@ -84,7 +84,7 @@ Describe "Assert-LessThan" {
             @{ Expected = "a" ; Actual = "z" ; Message = "Expected string 'z' to be less than string 'a', but it was not."},
             @{ Expected = 1.1 ; Actual = 10.1 ; Message = "Expected double '10.1' to be less than double '1.1', but it was not."},
             @{ Expected = 1.1D ; Actual = 10.1D ; Message = "Expected decimal '10.1' to be less than decimal '1.1', but it was not."}
-        ) { 
+        ) {
             param($Expected, $Actual, $Message)
             $error = { Assert-LessThan -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
             $error.Exception.Message | Verify-Equal $Message
@@ -101,7 +101,7 @@ Describe "Assert-LessThan" {
     }
 
     It "Given collection to Expected it throws" {
-        $error = { "dummy" | Assert-LessThan @() } | Verify-Throw 
+        $error = { "dummy" | Assert-LessThan @() } | Verify-Throw
         $error.Exception | Verify-Type ([ArgumentException])
     }
 }

--- a/tst/General/Assert-LessThanOrEqual.Tests.ps1
+++ b/tst/General/Assert-LessThanOrEqual.Tests.ps1
@@ -70,7 +70,7 @@ Describe "Assert-LessThanOrEqual" {
     }
 
     It "Fails for array input even if the last item is less than then expected value" {
-            $err = { 4,3,2,1 | Assert-LessThanOrEqual 3 } | Verify-Throw 
+            $err = { 4,3,2,1 | Assert-LessThanOrEqual 3 } | Verify-Throw
             $err.Exception | Verify-Type ([System.Management.Automation.RuntimeException])
     }
 
@@ -84,7 +84,7 @@ Describe "Assert-LessThanOrEqual" {
             @{ Expected = "a" ; Actual = "z" ; Message = "Expected string 'z' to be less than or equal to string 'a', but it was not."},
             @{ Expected = 1.1 ; Actual = 10.1 ; Message = "Expected double '10.1' to be less than or equal to double '1.1', but it was not."},
             @{ Expected = 1.1D ; Actual = 10.1D ; Message = "Expected decimal '10.1' to be less than or equal to decimal '1.1', but it was not."}
-        ) { 
+        ) {
             param($Expected, $Actual, $Message)
             $error = { Assert-LessThanOrEqual -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
             $error.Exception.Message | Verify-Equal $Message
@@ -101,7 +101,7 @@ Describe "Assert-LessThanOrEqual" {
     }
 
     It "Given collection to Expected it throws" {
-        $error = { "dummy" | Assert-LessThanOrEqual @() } | Verify-Throw 
+        $error = { "dummy" | Assert-LessThanOrEqual @() } | Verify-Throw
         $error.Exception | Verify-Type ([ArgumentException])
     }
 }

--- a/tst/General/Assert-NotEqual.Tests.ps1
+++ b/tst/General/Assert-NotEqual.Tests.ps1
@@ -65,7 +65,7 @@ InModuleScope -ModuleName Assert {
         Context "Validate messages" {
             It "Given two values that are the same '<value>' it returns expected message '<message>'" -TestCases @(
                 @{ Value = 1;  Message = "Expected int '1', to be different than the actual value, but they were the same."}
-            ) { 
+            ) {
                 param($Value, $Message)
                 $error = { Assert-NotEqual -Actual $Value -Expected $Value } | Verify-AssertionFailed
                 $error.Exception.Message | Verify-Equal $Message
@@ -82,7 +82,7 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Given collection to Expected it throws" {
-            $error = { "dummy" | Assert-NotEqual @() } | Verify-Throw 
+            $error = { "dummy" | Assert-NotEqual @() } | Verify-Throw
             $error.Exception | Verify-Type ([ArgumentException])
         }
     }

--- a/tst/General/Assert-NotNull.Tests.ps1
+++ b/tst/General/Assert-NotNull.Tests.ps1
@@ -1,14 +1,14 @@
 InModuleScope -ModuleName Assert {
     Describe "Assert-NotNull" {
-        It "Given a value it passes" { 
-            1 | Assert-NotNull 
+        It "Given a value it passes" {
+            1 | Assert-NotNull
         }
 
-        It "Given `$null it fails" { 
+        It "Given `$null it fails" {
             { $null | Assert-NotNull } | Verify-AssertionFailed
         }
 
-        It "Returns the given value" { 
+        It "Returns the given value" {
             1 | Assert-NotNull | Verify-NotNull
         }
 

--- a/tst/General/Assert-NotSame.Tests.ps1
+++ b/tst/General/Assert-NotSame.Tests.ps1
@@ -24,21 +24,21 @@ InModuleScope -ModuleName Assert {
 
         It "Given two values that are the same instance it returns expected message '<message>'" -TestCases @(
             @{ Value = "a"; Message = "Expected string 'a', to not be the same instance."}
-        ) { 
+        ) {
             param($Value, $Message)
             $error = { Assert-NotSame -Actual $Value -Expected $Value } | Verify-AssertionFailed
             $error.Exception.Message | Verify-Equal $Message
         }
-        
+
         It "Returns the value on output" {
             $expected = 1
             $expected | Assert-NotSame 7 | Verify-Equal $expected
         }
 
         It "Can be called with positional parameters" {
-            {   
+            {
                 $obj = New-Object -TypeName PSObject
-                Assert-NotSame $obj $obj 
+                Assert-NotSame $obj $obj
             } | Verify-AssertionFailed
         }
     }

--- a/tst/General/Assert-NotType.Tests.ps1
+++ b/tst/General/Assert-NotType.Tests.ps1
@@ -1,14 +1,14 @@
 InModuleScope -ModuleName Assert {
     Describe "Assert-NotType" {
-        It "Given value of expected type it fails" { 
+        It "Given value of expected type it fails" {
             { 1 | Assert-NotType ([int]) } | Verify-AssertionFailed
         }
 
-        It "Given an object of different type it passes" { 
+        It "Given an object of different type it passes" {
             1 | Assert-NotType ([string])
         }
 
-        It "Returns the given value" { 
+        It "Returns the given value" {
             'b' | Assert-NotType ([int]) | Verify-Equal 'b'
         }
 

--- a/tst/General/Assert-Null.Tests.ps1
+++ b/tst/General/Assert-Null.Tests.ps1
@@ -1,14 +1,14 @@
 InModuleScope -ModuleName Assert {
     Describe "Assert-Null" {
-        It "Given `$null it passes" { 
-            $null | Assert-Null 
+        It "Given `$null it passes" {
+            $null | Assert-Null
         }
 
-        It "Given an objects it fails" { 
+        It "Given an objects it fails" {
             { 1 | Assert-Null } | Verify-AssertionFailed
         }
 
-        It "Returns the given value" { 
+        It "Returns the given value" {
             $null | Assert-Null | Verify-Null
         }
 

--- a/tst/General/Assert-Same.Tests.ps1
+++ b/tst/General/Assert-Same.Tests.ps1
@@ -24,7 +24,7 @@ InModuleScope -ModuleName Assert {
 
         It "Given two values that are not the same instance '<expected>' and '<actual>' it returns expected message '<message>'" -TestCases @(
             @{ Expected = New-Object -TypeName PSObject ; Actual = New-Object -TypeName PSObject ; Message = "Expected PSObject '', to be the same instance but it was not."}
-        ) { 
+        ) {
             param($Expected, $Actual, $Message)
             $error = { Assert-Same -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
             $error.Exception.Message | Verify-Equal $Message

--- a/tst/General/Assert-Type.Tests.ps1
+++ b/tst/General/Assert-Type.Tests.ps1
@@ -1,14 +1,14 @@
 InModuleScope -ModuleName Assert {
     Describe "Assert-Type" {
-        It "Given value of expected type it passes" { 
+        It "Given value of expected type it passes" {
             1| Assert-Type ([int])
         }
 
-        It "Given an object of different type it fails" { 
+        It "Given an object of different type it fails" {
             { 1 | Assert-Type ([string]) } | Verify-AssertionFailed
         }
 
-        It "Returns the given value" { 
+        It "Returns the given value" {
             'b' | Assert-Type ([string]) | Verify-Equal 'b'
         }
 

--- a/tst/String/Assert-Like.Tests.ps1
+++ b/tst/String/Assert-Like.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Assert-Like" {
             Assert-Like -Actual $Actual -Expected $Expected
         }
 
-        It "Fails given strings with different values" { 
+        It "Fails given strings with different values" {
             { Assert-Like -Expected "abc" -Actual "def" } | Verify-AssertionFailed
         }
 
@@ -21,7 +21,7 @@ Describe "Assert-Like" {
             @{ Actual = "ABc";  Expected = "def" },
             @{ Actual = "aBc";  Expected = "def" },
             @{ Actual = "ABC";  Expected = "def" }
-        ) { 
+        ) {
             param ($Actual, $Expected)
             { Assert-Like -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
         }
@@ -30,11 +30,11 @@ Describe "Assert-Like" {
             @{ Actual = "abc ";  Expected = "abc" },
             @{ Actual = "abc ";  Expected = "abc" },
             @{ Actual = "ab c";  Expected = "abc" }
-        ) { 
+        ) {
             param ($Actual, $Expected)
             { Assert-Like -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
         }
-        
+
         It "Passes given strings with different case that start with a given pattern. comparing '<actual>':'<expected>'" -TestCases @(
             @{ Actual = "ABcdef";  Expected = "abc*" },
             @{ Actual = "aBcdef";  Expected = "abc*" },
@@ -105,7 +105,7 @@ Describe "Assert-Like" {
     }
 
     It "Throws when given a collection to avoid confusing matches of the last item only" {
-        $err = { "bde", "abc" | Assert-Like -Expected "abc" } | Verify-Throw 
+        $err = { "bde", "abc" | Assert-Like -Expected "abc" } | Verify-Throw
         $err.Exception.Message | Verify-Equal "Actual is expected to be string, to avoid confusing behavior that -like operator exhibits with collections. To assert on collections use Assert-Any, Assert-All or some other collection assertion."
     }
 
@@ -118,7 +118,7 @@ Describe "Assert-Like" {
             @{ Actual = 'a'; Expected = 'b'; Message = "Expected the string 'a' to match 'b' but it did not." }
             @{ Actual = 'ab'; Expected = 'd*'; Message = "Expected the string 'ab' to match 'd*' but it did not." }
             @{ Actual = 'something'; Expected = '*abc*'; Message = "Expected the string 'something' to match '*abc*' but it did not." }
-        ) { 
+        ) {
             param ($Actual, $Expected, $Message)
             $err =  { Assert-Like -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
             $err.Exception.Message | Verify-Equal $Message
@@ -128,7 +128,7 @@ Describe "Assert-Like" {
             @{ Actual = 'a'; Expected = 'B'; Message = "Expected the string 'a' to case sensitively match 'B' but it did not." }
             @{ Actual = 'ab'; Expected = 'B*'; Message = "Expected the string 'ab' to case sensitively match 'B*' but it did not." }
             @{ Actual = 'something'; Expected = '*SOME*'; Message = "Expected the string 'something' to case sensitively match '*SOME*' but it did not." }
-        ) { 
+        ) {
             param ($Actual, $Expected, $Message)
             $err =  { Assert-Like -Actual $Actual -Expected $Expected -CaseSensitive } | Verify-AssertionFailed
             $err.Exception.Message | Verify-Equal $Message

--- a/tst/String/Assert-NotLike.Tests.ps1
+++ b/tst/String/Assert-NotLike.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Assert-NotLike" {
             { Assert-NotLike -Actual $Actual -Expected $Expected  } | Verify-AssertionFailed
         }
 
-        It "Passes given strings with different values" { 
+        It "Passes given strings with different values" {
             Assert-NotLike -Expected "abc" -Actual "def"
         }
 
@@ -21,7 +21,7 @@ Describe "Assert-NotLike" {
             @{ Actual = "ABc";  Expected = "def" },
             @{ Actual = "aBc";  Expected = "def" },
             @{ Actual = "ABC";  Expected = "def" }
-        ) { 
+        ) {
             param ($Actual, $Expected)
             Assert-NotLike -Actual $Actual -Expected $Expected
         }
@@ -30,11 +30,11 @@ Describe "Assert-NotLike" {
             @{ Actual = "abc ";  Expected = "abc" },
             @{ Actual = "abc ";  Expected = "abc" },
             @{ Actual = "ab c";  Expected = "abc" }
-        ) { 
+        ) {
             param ($Actual, $Expected)
             Assert-NotLike -Actual $Actual -Expected $Expected
         }
-        
+
         It "Fails given strings with different case that start with a given pattern. comparing '<actual>':'<expected>'" -TestCases @(
             @{ Actual = "ABcdef";  Expected = "abc*" },
             @{ Actual = "aBcdef";  Expected = "abc*" },
@@ -109,7 +109,7 @@ Describe "Assert-NotLike" {
     }
 
     It "Throws when given a collection to avoid confusing matches of the last item only" {
-        $err = { "bde", "abc" | Assert-NotLike -Expected "abc" } | Verify-Throw 
+        $err = { "bde", "abc" | Assert-NotLike -Expected "abc" } | Verify-Throw
         $err.Exception.Message | Verify-Equal "Actual is expected to be string, to avoid confusing behavior that -like operator exhibits with collections. To assert on collections use Assert-Any, Assert-All or some other collection assertion."
     }
 
@@ -118,7 +118,7 @@ Describe "Assert-NotLike" {
             @{ Actual = 'a'; Expected = 'A'; Message = "Expected the string 'a' to not match 'A' but it matched it." }
             @{ Actual = 'ab'; Expected = 'a*'; Message = "Expected the string 'ab' to not match 'a*' but it matched it." }
             @{ Actual = 'something'; Expected = 'SOME*'; Message = "Expected the string 'something' to not match 'SOME*' but it matched it." }
-        ) { 
+        ) {
             param ($Actual, $Expected, $Message)
             $err =  { Assert-NotLike -Actual $Actual -Expected $Expected } | Verify-AssertionFailed
             $err.Exception.Message | Verify-Equal $Message
@@ -128,7 +128,7 @@ Describe "Assert-NotLike" {
             @{ Actual = 'a'; Expected = 'a'; Message = "Expected the string 'a' to case sensitively not match 'a' but it matched it." }
             @{ Actual = 'AB'; Expected = 'A*'; Message = "Expected the string 'AB' to case sensitively not match 'A*' but it matched it." }
             @{ Actual = 'SOMETHING'; Expected = '*SOME*'; Message = "Expected the string 'SOMETHING' to case sensitively not match '*SOME*' but it matched it." }
-        ) { 
+        ) {
             param ($Actual, $Expected, $Message)
             $err =  { Assert-NotLike -Actual $Actual -Expected $Expected -CaseSensitive } | Verify-AssertionFailed
             $err.Exception.Message | Verify-Equal $Message

--- a/tst/String/Assert-StringEqual.Tests.ps1
+++ b/tst/String/Assert-StringEqual.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope -ModuleName Assert {
                 Test-StringEqual -Expected $l -Actual $r | Verify-True
             }
 
-            It "strings with different values are not equal" { 
+            It "strings with different values are not equal" {
                 Test-StringEqual -Expected "abc" -Actual "def" | Verify-False
             }
 
@@ -22,7 +22,7 @@ InModuleScope -ModuleName Assert {
                 @{l = "ABc"; r = "def" },
                 @{l = "aBc"; r = "def" },
                 @{l = "ABC"; r = "def" }
-            ) { 
+            ) {
                 param ($l, $r)
                 Test-StringEqual -Expected $l -Actual $r | Verify-False
             }
@@ -31,7 +31,7 @@ InModuleScope -ModuleName Assert {
                 @{l = "abc "; r = "abc" },
                 @{l = "abc "; r = "abc" },
                 @{l = "ab c"; r = "abc" }
-            ) { 
+            ) {
                 param ($l, $r)
                 Test-StringEqual -Expected $l -Actual $r | Verify-False
             }
@@ -54,7 +54,7 @@ InModuleScope -ModuleName Assert {
                 @{l = "abc "; r = "abc" },
                 @{l = "ab c"; r = "abc" },
                 @{l = "ab c"; r = "a b c" }
-            ) { 
+            ) {
                 param ($l, $r)
                 Test-StringEqual -Expected $l -Actual $r -IgnoreWhiteSpace | Verify-True
             }
@@ -70,17 +70,17 @@ InModuleScope -ModuleName Assert {
     }
 
     Describe "Assert-StringEqual" {
-        It "Does nothing when string are the same" { 
+        It "Does nothing when string are the same" {
             Assert-StringEqual -Expected "abc" -Actual "abc"
         }
 
         It "Throws when strings are different" {
-            { Assert-StringEqual -Expected "abc" -Actual "bde" } | Verify-AssertionFailed 
+            { Assert-StringEqual -Expected "abc" -Actual "bde" } | Verify-AssertionFailed
         }
 
         It "Throws with default message when test fails" {
             $expected = Get-StringEqualDefaultFailureMessage -Expected "abc" -Actual "bde"
-            $exception = { Assert-StringEqual -Expected "abc" -Actual "bde" } | Verify-AssertionFailed 
+            $exception = { Assert-StringEqual -Expected "abc" -Actual "bde" } | Verify-AssertionFailed
             "$exception" | Verify-Equal $expected
         }
 

--- a/tst/String/Assert-StringNotEqual.Tests.ps1
+++ b/tst/String/Assert-StringNotEqual.Tests.ps1
@@ -8,12 +8,12 @@ InModuleScope -ModuleName Assert {
     }
 
     Describe "Assert-StringNotEqual" {
-        It "Does nothing when string are different" { 
+        It "Does nothing when string are different" {
             Assert-StringNotEqual -Expected "abc" -Actual "bde"
         }
 
         It "Throws when strings are the same" {
-            { Assert-StringNotEqual -Expected "abc" -Actual "abc" } | Verify-AssertionFailed 
+            { Assert-StringNotEqual -Expected "abc" -Actual "abc" } | Verify-AssertionFailed
         }
 
         It "Throws with default message when test fails" {

--- a/tst/TestHelpers.psm1
+++ b/tst/TestHelpers.psm1
@@ -1,7 +1,7 @@
 function New-Dictionary ([hashtable]$Hashtable) {
     $d = new-object "Collections.Generic.Dictionary[string,object]"
-    
-    $Hashtable.GetEnumerator() | foreach { $d.Add($_.Key, $_.Value) }
+
+    $Hashtable.GetEnumerator() | ForEach-Object { $d.Add($_.Key, $_.Value) }
 
     $d
 }

--- a/tst/test.ps1
+++ b/tst/test.ps1
@@ -5,7 +5,7 @@ $here = $MyInvocation.MyCommand.Path | Split-Path
 Set-StrictMode -Version Latest
 
 try {
-    pushd $here
+    Push-Location $here
 
     # this is useful also for running in docker
     # but keeping it without the build switch
@@ -14,13 +14,13 @@ try {
     if ($CIBuild) {
         $minimumNugetProviderVersion = '2.8.5.201'
         # not using the -Name parameter because it throws when Nuget is not installed
-        if (-not (Get-PackageProvider -ListAvailable | Where { $_.Name -eq "Nuget" -and $_.Version -ge $minimumNugetProviderVersion })) {
+        if (-not (Get-PackageProvider -ListAvailable | Where-Object { $_.Name -eq "Nuget" -and $_.Version -ge $minimumNugetProviderVersion })) {
             "Installing Nuget package provider."
             Install-PackageProvider -Name NuGet -MinimumVersion $minimumNugetProviderVersion -Force
         }
 
         $minimumPesterVersion = "4.4.0"
-        if (-not (Get-Module -ListAvailable | Where { $_.Name -eq"Pester" -and $_.Version -ge $minimumPesterVersion })) {
+        if (-not (Get-Module -ListAvailable | Where-Object { $_.Name -eq"Pester" -and $_.Version -ge $minimumPesterVersion })) {
             "Installing Pester."
             Install-Module -Name Pester -Force -SkipPublisherCheck -MinimumVersion $minimumPesterVersion -Scope CurrentUser
         }
@@ -31,7 +31,7 @@ try {
     # import the tested module
     Import-Module ./../Assert.psd1
 
-    # import modules and utilities for testing 
+    # import modules and utilities for testing
     Import-Module Pester
     Import-Module ./TestHelpers.psm1
     Import-Module ./../Axiom/src/Axiom.psm1 -WarningAction SilentlyContinue
@@ -50,5 +50,5 @@ try {
     }
 }
 finally {
-    popd
+    Pop-Location
 }

--- a/wip/CompareBiggerObjects.ps1
+++ b/wip/CompareBiggerObjects.ps1
@@ -1,11 +1,11 @@
 Get-Module Assert | Remove-Module
 Import-module ./Assert.psd1
 
-$expected = [PSCustomObject]@{ 
-    Name = 'Jakub' 
+$expected = [PSCustomObject]@{
+    Name = 'Jakub'
     Age = 28
     KnowsPowerShell = $true
-    Languages = 'Czech', 'English' 
+    Languages = 'Czech', 'English'
     ProgrammingLanguage =
         [PSCustomObject]@{
             Name = 'PowerShell'
@@ -13,15 +13,15 @@ $expected = [PSCustomObject]@{
         }
 }
 
-$actual = [PSCustomObject]@{ 
+$actual = [PSCustomObject]@{
     Name = 'Jkb'
     KnowsPowerShell = 0
     Languages = 'Czech', 'English', 'German'
-    ProgrammingLanguage = 
+    ProgrammingLanguage =
         [PSCustomObject]@{
             Name = 'C#'
             Type = 'ObjectOriented'
-        }    
+        }
 }
 
 Assert-Equivalent -a $actual -e $expected -Verbose

--- a/wip/VerboseOutput.ps1
+++ b/wip/VerboseOutput.ps1
@@ -17,62 +17,62 @@ Import-module ./Assert.psd1
         "`n"
     }
 
-    
+
     function mm ($string) { m "- $string" }
     function m ($string) { Write-Host -fore Cyan $string}
 m ("-*"*40)
 #mm "nulls"
-#c -a 1 -e $null 
-#c -a $null -e $null 
+#c -a 1 -e $null
+#c -a $null -e $null
 
 
 #mm "values"
 
 #mm "bools"
 #m "fixing bool for expected"
-#c -a $false -e 'False' 
-#c -a $true -e 'False' 
+#c -a $false -e 'False'
+#c -a $true -e 'False'
 
 #m "fixing bool for actual"
-#c -a 'False' -e $false 
-#c -a 'False' -e $true 
+#c -a 'False' -e $false
+#c -a 'False' -e $true
 
 #m compare scriptblocks by content
-# c -a {} -e {} 
+# c -a {} -e {}
 # c -a { "hello" } -e { "hello" }
 
-# c -a { } -e {} 
+# c -a { } -e {}
 # c -a { "hello"} -e { "hello" }
 
 # m "normal boolean comparison"
-# c -a $true -e $true 
-# c -a $false -e $false 
-# c -a $true -e $false 
-# c -a $false -e $true 
-# c -a "" -e $true 
-# c -a 1 -e $true 
+# c -a $true -e $true
+# c -a $false -e $false
+# c -a $true -e $false
+# c -a $false -e $true
+# c -a "" -e $true
+# c -a 1 -e $true
 # c -a 0 -e $true
 # c -a {} -e ""
 # c -a "" -e {}
 
-m compare objects 
+m compare objects
 
 
-$expected = [PSCustomObject]@{ 
-    Name = 'Jakub' 
+$expected = [PSCustomObject]@{
+    Name = 'Jakub'
     Age = 28
     KnowsPowerShell = $true
-    Languages = 'Czech', 'English' 
+    Languages = 'Czech', 'English'
 }
 
-$actual = [PSCustomObject]@{ 
+$actual = [PSCustomObject]@{
     Name = 'Jkb'
     KnowsPowerShell = 0
     Languages = 'Czech', 'English', 'German'
 }
 
 c -a $actual -e $expected
-# m hashtables 
+# m hashtables
 # c -a @{} -e @{}
 # c -a @() -e @{}
 


### PR DESCRIPTION
Auto-fix PSSA warnings:
- Use proper cmdet name instead of alias for better readability and slightly faster runtime performance due to faster command lookup
- Remove trailing whitespace, resulting in a smaller payload of the whole module and git repo

I did this as follows to preserve existing Ascii encoding:
````powershell
Invoke-ScriptAnalyzer . -Recurse -Fix;  gci -File -Filter *.ps1  -Recurse | % { $c = cat $_.FullName -Raw; Set-Content -Path $_.fullname -Encoding Ascii -Value $c -NoNewline; }
````