### PR TITLE
Moved StrictOrder, PowerShell 7.0.0-preview.2 DBNull support and StrictEquality

### DIFF
--- a/Format/src/Format.psm1
+++ b/Format/src/Format.psm1
@@ -72,7 +72,7 @@ function Format-Dictionary ($Value) {
 }
 
 function Format-Nicely ($Value, [switch]$Pretty) {
-    if ($null -eq $Value)
+    if (Is-Null -Value $Value)
     {
         return Format-Null -Value $Value
     }

--- a/TypeClass/src/TypeClass.psm1
+++ b/TypeClass/src/TypeClass.psm1
@@ -1,3 +1,8 @@
+function Is-Null ($Value) {
+    # Since PowerShell 7.0 [DBNull] -eq $null.
+    $null -eq $Value -or $Value -is [DBNull] -or $Value.Psobject.TypeNames[0] -like '*System.DBNull'
+}
+
 function Is-Value ($Value) {
     $Value = $($Value)
     $Value -is [ValueType] -or $Value -is [string] -or $value -is [scriptblock]
@@ -50,6 +55,7 @@ function Is-DataRow ($Value) {
 }
 
 Export-ModuleMember -Function @(
+    'Is-Null'
     'Is-Value'
     'Is-Collection'
     'Is-DataTable'

--- a/src/Equivalence/Assert-Equivalent.ps1
+++ b/src/Equivalence/Assert-Equivalent.ps1
@@ -81,7 +81,7 @@ function Compare-CollectionEquivalent ($Expected, $Actual, $Property, $Options) 
         v "`nSearching for `$Expected[$e]:"
         $currentExpected = $Expected[$e]
         $found = $false
-        if ($StrictOrder) {
+        if ($Options.StrictOrder) {
             $currentActual = $Actual[$e]
             if ($taken -notcontains $e -and (-not (Compare-Equivalent -Expected $currentExpected -Actual $currentActual -Path $Property -Options $Options)))
             {
@@ -161,7 +161,7 @@ function Compare-DataTableEquivalent ($Expected, $Actual, $Property, $Options) {
     for ($e = 0; $e -lt $eEnd; $e++) {
         $currentExpected = $Expected.Rows[$e]
         $found = $false
-        if ($StrictOrder) {
+        if ($Options.StrictOrder) {
             $currentActual = $Actual.Rows[$e]
             if ((-not (Compare-Equivalent -Expected $currentExpected -Actual $currentActual -Path $Property -Options $Options)) -and $taken -notcontains $e) {
                 $taken += $e
@@ -660,8 +660,7 @@ function Assert-Equivalent {
     param(
         $Actual,
         $Expected,
-        $Options = (Get-EquivalencyOption),
-        [Switch] $StrictOrder
+        $Options = (Get-EquivalencyOption)
     )
 
     $areDifferent = Compare-Equivalent -Actual $Actual -Expected $Expected -Options $Options | Out-String
@@ -682,13 +681,15 @@ function Get-EquivalencyOption {
         [string[]] $ExcludePath = @(),
         [switch] $ExcludePathsNotOnExpected,
         [ValidateSet('Equivalency', 'Equality')]
-        [string] $Comparator = 'Equivalency'
+        [string] $Comparator = 'Equivalency',
+        [switch] $StrictOrder
     )
 
     [PSCustomObject]@{
-        ExcludedPaths = [string[]] $ExcludePath
+        ExcludedPaths             = [string[]] $ExcludePath
         ExcludePathsNotOnExpected = [bool] $ExcludePathsNotOnExpected
-        Comparator = [string] $Comparator
+        Comparator                = [string] $Comparator
+        StrictOrder               = [bool] $StrictOrder
     }
 }
 

--- a/tst/Equivalence/Assert-Equivalent.Options.Tests.ps1
+++ b/tst/Equivalence/Assert-Equivalent.Options.Tests.ps1
@@ -355,6 +355,12 @@
 
             $options = Get-EquivalencyOption -Comparator Equality
             { Assert-Equivalent -Actual $actual -Expected $expected -Options $options } | Verify-AssertionFailed
+
+            $DBNull = [DBNull]::Value
+            Assert-Equivalent -Actual $null -Expected $DBNull
+            Assert-Equivalent -Actual $DBNull -Expected $null
+            {Assert-Equivalent -Actual $null -Expected $DBNull -Options $options} | Should -Throw -ExpectedMessage 'Expected and actual are not equivalent!'
+            {Assert-Equivalent -Actual $DBNull -Expected $null -Options $options} | Should -Throw -ExpectedMessage 'Expected and actual are not equivalent!'
         }
     }
 

--- a/tst/Equivalence/Assert-Equivalent.Options.Tests.ps1
+++ b/tst/Equivalence/Assert-Equivalent.Options.Tests.ps1
@@ -355,15 +355,31 @@
 
             $options = Get-EquivalencyOption -Comparator Equality
             { Assert-Equivalent -Actual $actual -Expected $expected -Options $options } | Verify-AssertionFailed
+        }
 
-            $DBNull = [DBNull]::Value
-            Assert-Equivalent -Actual $null -Expected $DBNull
-            Assert-Equivalent -Actual $DBNull -Expected $null
-            {Assert-Equivalent -Actual $null -Expected $DBNull -Options $options} | Should -Throw -ExpectedMessage 'Expected and actual are not equivalent!'
-            {Assert-Equivalent -Actual $DBNull -Expected $null -Options $options} | Should -Throw -ExpectedMessage 'Expected and actual are not equivalent!'
+        $OptionsEquality = Get-EquivalencyOption -Comparator Equality
+        $OptionsStrictEquality = Get-EquivalencyOption -Comparator StrictEquality
+        $DBNull = [DBNull]::Value
+        It "Test <Actual> vs <Expected> with -Comparator 'Equivalency', 'Equality', 'StrictEquality'" -TestCases @(
+            @{ Actual = 'False' ; Expected = $false }
+            @{ Actual = $null; Expected = $DBNull }
+            @{ Actual = 5; Expected = '5' }
+            @{ Actual = { 'String' }; Expected = { 'String' } }
+        ) {
+            param($Expected, $Actual)
+            # Equivalent
+            Assert-Equivalent -Actual $Actual -Expected $Expected
+            Assert-Equivalent -Actual $Expected -Expected $Actual
+            # StrictEquality
+            { Assert-Equivalent -Actual $Actual -Expected $Expected -Options $OptionsStrictEquality } | Verify-AssertionFailed
+            { Assert-Equivalent -Actual $Expected -Expected $Actual -Options $OptionsStrictEquality } | Verify-AssertionFailed
+            # Equality
+            $AssertResult = try { Assert-Equivalent -Actual $Actual -Expected $Expected -Options $OptionsEquality ; $true} catch {$false}
+            $AssertResult -eq ($Expected -eq $Actual) | Verify-True
+            $AssertResult = try { Assert-Equivalent -Actual $Expected -Expected $Actual -Options $OptionsEquality ; $true} catch {$false}
+            $AssertResult -eq ($Actual -eq $Expected) | Verify-True
         }
     }
-
 
     Describe "Printing Options into difference report" {
 

--- a/tst/Equivalence/Assert-Equivalent.Tests.ps1
+++ b/tst/Equivalence/Assert-Equivalent.Tests.ps1
@@ -463,7 +463,7 @@ InModuleScope -ModuleName Assert {
             Assert-Equivalent -Actual $ActualDeserialized -Expected $ExpectedDeserialized
             Assert-Equivalent -Actual $Actual -Expected $ExpectedDeserialized
 
-            {Assert-Equivalent -Actual $Actual -Expected $Expected -StrictOrder} | Should -Throw
+            {Assert-Equivalent -Actual $Actual -Expected $Expected -Options (Get-EquivalencyOption -StrictOrder)} | Should -Throw
 
             $Actual.Rows[1].Name = 'D'
             {Assert-Equivalent -Actual $Actual -Expected $Expected} | Should -Throw


### PR DESCRIPTION
Hi
This pull is to replace in part the outdated pull https://github.com/nohwnd/Assert/pull/34.
There are 3 things covered here:

Commit https://github.com/nohwnd/Assert/commit/c7703405086e8b47f56c43da113ff1ffc748a405 - Moved StrictOrder to Get-EquivalencyOption from Assert-Equivalent so it will be in the same place with all the other configuration options.

Commit https://github.com/nohwnd/Assert/commit/6aea1e058bb2261f71f75b51a644284e73f2966f -  Deserialize DBNull support added as Deserialize DataTable and DataRow are already supported in the existing version and it is missing to complete the set to make this usable.

Commit https://github.com/nohwnd/Assert/commit/959c9ca38ee7eccbe4d03fc3a485c44b10b2b426 - Added a new -Comparator  Option 'StrictEquality'
Use this code to illustrate the 3 modes ('Equivalency', 'Equality', 'StrictEquality')
``` powershell
$OptionsEquality = Get-EquivalencyOption -Comparator Equality
$OptionsStrictEquality = Get-EquivalencyOption -Comparator StrictEquality
$DBNull = [DBNull]::Value
$TestCases = @(
    #{ $Expected = 'Same'; $Actual = 'Same' }
    { $Expected = 'False'; $Actual = $false }
    { $Expected = $null; $Actual = $DBNull }
    { $Expected = 5; $Actual = '5' }
    { $Expected = { 'AAA' }; $Actual = { 'AAA' } }
)
$Results = @()
foreach ($TestCase in $TestCases) {
    . $TestCase
    $Results += [PSCustomObject]@{
        Test          = $TestCase.ToString()
        PsForward     = ($Expected -eq $Actual)
        PsReverse     = ($Actual -eq $Expected)
        AssEqualityF = . { try { Assert-Equivalent -Actual $Actual -Expected $Expected -Options $OptionsEquality ; $true } catch { $false } }
        AssEqualityR = . { try { Assert-Equivalent -Actual $Expected -Expected $Actual -Options $OptionsEquality ; $true } catch { $false } }
        AssertF = . { try { Assert-Equivalent -Actual $Actual -Expected $Expected ; $true } catch { $false } }
        AssertR = . { try { Assert-Equivalent -Actual $Expected -Expected $Actual ; $true } catch { $false } }
        AssSEqualityF = . { try { Assert-Equivalent -Actual $Actual -Expected $Expected -Options $OptionsStrictEquality ; $true } catch { $false } }
        AssSEqualityR = . { try { Assert-Equivalent -Actual $Expected -Expected $Actual -Options $OptionsStrictEquality ; $true } catch { $false } }
    }
}
$Results | Format-Table
```
PowerShell 7.0.0-preview.2
```
Test                                         PsForward PsReverse AssEqualityF AssEqualityR AssertF AssertR AssSEqualityF AssSEqualityR
----                                         --------- --------- ------------ ------------ ------- ------- ------------- -------------
 $Expected = 'False'; $Actual = $false            True     False         True        False    True    True         False         False
 $Expected = $null; $Actual = $DBNull             True      True         True         True    True    True         False         False
 $Expected = 5; $Actual = '5'                     True      True         True         True    True    True         False         False
 $Expected = { 'AAA' }; $Actual = { 'AAA' }      False     False        False        False    True    True         False         False
```
PowerShell 5.1
```
Test                                         PsForward PsReverse AssEqualityF AssEqualityR AssertF AssertR AssSEqualityF AssSEqualityR
----                                         --------- --------- ------------ ------------ ------- ------- ------------- -------------
 $Expected = 'False'; $Actual = $false            True     False         True        False    True    True         False         False
 $Expected = $null; $Actual = $DBNull            False     False        False        False    True    True         False         False
 $Expected = 5; $Actual = '5'                     True      True         True         True    True    True         False         False
 $Expected = { 'AAA' }; $Actual = { 'AAA' }      False     False        False        False    True    True         False         False
```
Equivalency - Return true in all the tested situations, using your existing equivalency code.
StrictEquality - Return false in all the tested situations, it verifies that the Type is the same in addition to the value test.
Equality - Exactly the same as doing `$Expected -eq $Actual` (Can return different results depending on the PS version and the side of the variable (`'False' -eq $false` vs `$false -eq 'False'`)).

Since PowerShell 7.0.0-preview.2 DBNull -eq $null.
So in Equality mode the result will depend on the PowerShell version as `[DBNull]::Value -eq $null` will depend on the PowerShell version.
In Equivalency mode this inconsistency is fixed to reflect the spirit of PS7 and it will be true in all PS versions.
In StrictEquality it will return false as in StrictEquality mode the Types need to be identical to pass.