### PR TITLE
Add pipeline input

### DIFF
--- a/src/Equivalence/Assert-Equivalent.ps1
+++ b/src/Equivalence/Assert-Equivalent.ps1
@@ -658,7 +658,9 @@ function Compare-Equivalent {
 function Assert-Equivalent {
     [CmdletBinding()]
     param(
+        [Parameter(Position = 1, ValueFromPipeline = $true)]
         $Actual,
+        [Parameter(Position = 0, Mandatory)]
         $Expected,
         $Options = (Get-EquivalencyOption),
         [Switch] $StrictOrder

--- a/tst/Equivalence/Assert-Equivalent.Tests.ps1
+++ b/tst/Equivalence/Assert-Equivalent.Tests.ps1
@@ -479,5 +479,15 @@ InModuleScope -ModuleName Assert {
         It "Can be called with positional parameters" {
             { Assert-Equivalent 1 2 } | Verify-AssertionFailed
         }
+
+        It "Can be passed pipeline input and a named parameter" {
+            { 1 | Assert-Equivalent -Expected 1} | Should -Not -Throw
+            { 1 | Assert-Equivalent -Expected 2} | Verify-AssertionFailed
+        }
+
+        It "Can be passed pipeline input and a positional parameter" {
+            { 1 | Assert-Equivalent 1} | Should -Not -Throw
+            { 1 | Assert-Equivalent 2} | Verify-AssertionFailed
+        }
     }
 }

--- a/tst/Equivalence/Assert-Equivalent.Tests.ps1
+++ b/tst/Equivalence/Assert-Equivalent.Tests.ps1
@@ -481,13 +481,13 @@ InModuleScope -ModuleName Assert {
         }
 
         It "Can be passed pipeline input and a named parameter" {
-            { 1 | Assert-Equivalent -Expected 1} | Should -Not -Throw
-            { 1 | Assert-Equivalent -Expected 2} | Verify-AssertionFailed
+            1 | Assert-Equivalent -Expected 1
+            { 1 | Assert-Equivalent -Expected 2 } | Verify-AssertionFailed
         }
 
         It "Can be passed pipeline input and a positional parameter" {
-            { 1 | Assert-Equivalent 1} | Should -Not -Throw
-            { 1 | Assert-Equivalent 2} | Verify-AssertionFailed
+            1 | Assert-Equivalent 1
+            { 1 | Assert-Equivalent 2 } | Verify-AssertionFailed
         }
     }
 }


### PR DESCRIPTION
As discussed in issue #51. I've added tests to the last Compare-Equivalent describe block. The entire test suite ran successfully locally beforehand and after the changes. The tests are really basic though, feel free to suggest or apply changes.